### PR TITLE
fix: update OrderRequest type

### DIFF
--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -1145,8 +1145,18 @@ export class RestClient extends BaseRestClient {
    *
    */
 
-  getInstruments(params: unknown): Promise<Instrument[]> {
-    return this.get('/api/v5/public/instruments', params);
+  getInstruments(
+    instType: InstrumentType,
+    uly?: string,
+    instFamily?: string,
+    instId?: string
+  ): Promise<Instrument[]> {
+    return this.get('/api/v5/public/instruments', {
+      instType,
+      uly,
+      instFamily,
+      instId,
+    });
   }
 
   getDeliveryExerciseHistory(params: unknown): Promise<unknown[]> {

--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -96,6 +96,7 @@ import {
   APICredentials,
   RestClientOptions,
   APIMarket,
+  Instrument,
 } from './types';
 import { ASSET_BILL_TYPE } from './constants';
 
@@ -1144,7 +1145,7 @@ export class RestClient extends BaseRestClient {
    *
    */
 
-  getInstruments(params: unknown): Promise<unknown[]> {
+  getInstruments(params: unknown): Promise<Instrument[]> {
     return this.get('/api/v5/public/instruments', params);
   }
 

--- a/src/types/rest/request/trade.ts
+++ b/src/types/rest/request/trade.ts
@@ -89,6 +89,8 @@ export interface ClosePositionRequest {
   mgnMode: MarginMode;
   ccy?: string;
   autoCxl?: boolean;
+  clOrdId?: string;
+  tag?: string;
 }
 
 export interface FillsHistoryRequest {

--- a/src/types/rest/request/trade.ts
+++ b/src/types/rest/request/trade.ts
@@ -145,5 +145,5 @@ export interface OrderRequest {
   tpTriggerPxType?: PriceTriggerType;
   slTriggerPxType?: PriceTriggerType;
   /** Quick margin type */
-  quickMgnType?: string;
+  quickMgnType?: 'manual' | 'auto_borrow' | 'auto_repay';
 }

--- a/src/types/rest/request/trade.ts
+++ b/src/types/rest/request/trade.ts
@@ -137,4 +137,13 @@ export interface OrderRequest {
   /** A spot buy on BTC-USDT with "base_ccy" would mean the QTY (sz) is in USDT */
   tgtCcy?: 'base_ccy' | 'quote_ccy';
   banAmend?: boolean;
+  /** Take Profit & Stop Loss params */
+  tpTriggerPx?: string;
+  tpOrdPx?: string;
+  slTriggerPx?: string;
+  slOrdPx?: string;
+  tpTriggerPxType?: PriceTriggerType;
+  slTriggerPxType?: PriceTriggerType;
+  /** Quick margin type */
+  quickMgnType?: string;
 }

--- a/src/types/rest/response/public-data.ts
+++ b/src/types/rest/response/public-data.ts
@@ -75,3 +75,34 @@ export interface Trade {
   tradeId: string;
   ts: string;
 }
+
+export interface Instrument {
+  instType: InstrumentType;
+  instId: string;
+  uly: string;
+  instFamily: string;
+  category: string;
+  baseCcy: string;
+  quoteCcy: string;
+  settCcy: string;
+  ctVal: string;
+  ctMult: string;
+  ctValCcy: string;
+  optType: string;
+  stk: string;
+  listTime: string;
+  expTime: string;
+  lever: string;
+  tickSz: string;
+  lotSz: string;
+  minSz: string;
+  ctType: string;
+  alias: string;
+  state: string;
+  maxLmtSz: string;
+  maxMktSz: string;
+  maxTwapSz: string;
+  maxIcebergSz: string;
+  maxTriggerSz: string;
+  maxStopSz: string;
+}


### PR DESCRIPTION
## Summary
Updated `OrderRequest` & `ClosePositionRequest` type to feature all supported params according to docs.
Added `Instrument` type for `/api/v5/public/instruments` response


## Additional Information
