### PR TITLE
v 1.1.4: feat() use crypto-js package instead of built-in crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "okx-api",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "okx-api",
-      "version": "1.1.2",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",
+        "crypto-js": "^4.2.0",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7.4.0"
       },
       "devDependencies": {
+        "@types/crypto-js": "^4.1.3",
         "@types/jest": "^28.1.4",
         "@types/node": "^14.14.7",
         "eslint": "^8.19.0",
@@ -1166,6 +1168,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.3.tgz",
+      "integrity": "sha512-YP1sYYayLe7Eg5oXyLLvOLfxBfZ5Fgpz6sVWkpB18wDMywCLPWmqzRz+9gyuOoLF0fzDTTFwlyNbx7koONUwqA==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
@@ -1963,6 +1971,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6092,6 +6105,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/crypto-js": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.3.tgz",
+      "integrity": "sha512-YP1sYYayLe7Eg5oXyLLvOLfxBfZ5Fgpz6sVWkpB18wDMywCLPWmqzRz+9gyuOoLF0fzDTTFwlyNbx7koONUwqA==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
@@ -6753,6 +6772,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okx-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Complete & robust Node.js SDK for OKX's REST APIs and WebSockets, with TypeScript & end-to-end tests",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,10 +23,12 @@
   "contributors": [],
   "dependencies": {
     "axios": "^0.21.0",
+    "crypto-js": "^4.2.0",
     "isomorphic-ws": "^4.0.1",
     "ws": "^7.4.0"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.1.3",
     "@types/jest": "^28.1.4",
     "@types/node": "^14.14.7",
     "eslint": "^8.19.0",

--- a/src/util/node-support.ts
+++ b/src/util/node-support.ts
@@ -1,5 +1,6 @@
-import { createHmac } from 'crypto';
+import * as CryptoJS from 'crypto-js'
 
 export function signMessage(message: string, secret: string): string {
-  return createHmac('sha256', secret).update(message).digest('base64');
+  const sha256 = CryptoJS.HmacSHA256(message, secret)
+  return CryptoJS.enc.Base64.stringify(sha256);
 }


### PR DESCRIPTION
## Summary
Use `crypto-js` module to be able to use library in both node and browser environments