### PR TITLE
Two params are missed for GET / Order history (last 3 months)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "okx-api",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "okx-api",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okx-api",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Complete & robust Node.js SDK for OKX's REST APIs and WebSockets, with TypeScript & end-to-end tests",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/rest/request/trade.ts
+++ b/src/types/rest/request/trade.ts
@@ -145,6 +145,8 @@ export interface OrderHistoryRequest {
   category?: string;
   after?: string;
   before?: string;
+  begin?: string;
+  end?: string;
   limit?: string;
 }
 


### PR DESCRIPTION
## Summary
Two params are missed for GET / Order history (last 3 months)
The "begin" and "end" parameters for the filter with the timestamp are needed for this endpoint. 

## Additional Information
https://www.okx.com/docs-v5/en/#order-book-trading-trade-get-order-history-last-3-months


