### PR TITLE
Add WS-Placed Order Confirmation Message Handler

### DIFF
--- a/src/types/websockets/event.ts
+++ b/src/types/websockets/event.ts
@@ -1,11 +1,34 @@
 import { WsChannel } from './request';
 
 export interface WsEvent {
-  event: 'error' | 'login' | 'subscribe' | 'unsubscribe' | 'channel-conn-count';
+  event:
+    | 'error'
+    | 'login'
+    | 'subscribe'
+    | 'unsubscribe'
+    | 'channel-conn-count'
+    | 'order';
   code?: string;
   msg?: string;
   arg?: any;
   data?: any;
+}
+
+export interface WsOrderEvent {
+  id: string;
+  op: 'order';
+  data: {
+    clOrdId: string;
+    ordId: string;
+    tag: string;
+    ts: string;
+    sCode: string;
+    sMsg: string;
+  }[];
+  code: string;
+  msg: string;
+  inTime: string;
+  outTime: string;
 }
 
 export interface WsDataEvent<T = any> {

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -1,4 +1,4 @@
-import { WsDataEvent, WsEvent, WsLoginEvent } from '../types';
+import { WsDataEvent, WsEvent, WsLoginEvent, WsOrderEvent } from '../types';
 import { APIResponse } from '../types/rest';
 
 export function isRawAPIResponse(
@@ -36,6 +36,18 @@ export function isWsDataEvent(evtData: unknown): evtData is WsDataEvent {
   if ('arg' in evtData && 'data' in evtData) {
     return true;
   }
+  return false;
+}
+
+export function isWsOrderEvent(evtData: unknown): evtData is WsOrderEvent {
+  if (typeof evtData !== 'object' || !evtData) {
+    return false;
+  }
+
+  if ('data' in evtData && 'op' in evtData && evtData.op === 'order') {
+    return true;
+  }
+
   return false;
 }
 

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -22,6 +22,7 @@ import {
   isWsDataEvent,
   isWsErrorEvent,
   isWsLoginEvent,
+  isWsOrderEvent,
   isWsPong,
   isWsSubscribeEvent,
   isWsUnsubscribeEvent,
@@ -761,6 +762,19 @@ export class WebsocketClient extends EventEmitter {
 
       if (isConnCountEvent(msg)) {
         return this.emit('response', { ...msg, wsKey });
+      }
+
+      if (isWsOrderEvent(msg)) {
+        return this.emit('response', {
+          data: msg.data,
+          event: 'order',
+          code: msg.code,
+          msg: msg.msg,
+          arg: {
+            uid: msg.id,
+          },
+          wsKey,
+        });
       }
 
       this.logger.error('Unhandled/unrecognised ws event message', {


### PR DESCRIPTION
## Summary

When placing an order via [OKX WS API](https://www.okx.com/docs-v5/en/#order-book-trading-trade-ws-place-order), an order state confirmation is emitted. User-defined `clOrdId` field is crucial for further order lifecycle tracking via `orders` channel. This field is returned by OKX API upon order confirmation message, which is currently just logged as `Unhandled/unrecognised ws event message` and thus does not propagate to algorithmic trader directly.

## Additional Information
No breaking changes introduced