### PR TITLE
fix(v3.0.5, #137): handling for mixed-auth connections should only auth once private topic is requested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "okx-api",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "okx-api",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okx-api",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Complete Node.js SDK for OKX's REST APIs and WebSockets, with TypeScript & end-to-end tests",
   "scripts": {
     "test": "jest",

--- a/src/util/websocket-util.ts
+++ b/src/util/websocket-util.ts
@@ -148,16 +148,20 @@ export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
 
 export const PRIVATE_WS_KEYS: WsKey[] = [
   WS_KEY_MAP.prodPrivate,
-  WS_KEY_MAP.prodBusiness,
   WS_KEY_MAP.prodDemoPrivate,
-  WS_KEY_MAP.prodDemoBusiness,
   WS_KEY_MAP.eeaLivePrivate,
-  WS_KEY_MAP.eeaLiveBusiness,
   WS_KEY_MAP.eeaDemoPrivate,
-  WS_KEY_MAP.eeaDemoBusiness,
   WS_KEY_MAP.usLivePrivate,
-  WS_KEY_MAP.usLiveBusiness,
   WS_KEY_MAP.usDemoPrivate,
+];
+
+// These sometimes need auth, depending on the topic
+export const MIXED_WS_KEYS: WsKey[] = [
+  WS_KEY_MAP.prodBusiness,
+  WS_KEY_MAP.prodDemoBusiness,
+  WS_KEY_MAP.eeaLiveBusiness,
+  WS_KEY_MAP.eeaDemoBusiness,
+  WS_KEY_MAP.usLiveBusiness,
   WS_KEY_MAP.usDemoBusiness,
 ];
 
@@ -214,7 +218,7 @@ export function getDemoWsKey(wsKey: WsKey): WsKey {
 }
 
 /** Used to automatically determine if a sub request should be to the public or private ws (when there's two) */
-const PRIVATE_CHANNELS = [
+export const PRIVATE_CHANNELS = [
   'account',
   'positions',
   'balance_and_position',


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
- Fixes #137 
- This moves business connections to a "mixed" type, they sometimes require auth, depending on the requested topic.
- This introduces a guard when subscribing, in addition to the "when connecting" guard, so if any topic requires auth and this connection hasn't been authenticated yet, the auth workflow will be called first.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
