### PR TITLE
feat(v3.1.6): add move positions functionality and update event contract endpoints

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,380 +49,382 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAccountInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L481) | :closed_lock_with_key:  | GET | `/api/v5/account/instruments` |
-| [getBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L487) | :closed_lock_with_key:  | GET | `/api/v5/account/balance` |
-| [getPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L491) | :closed_lock_with_key:  | GET | `/api/v5/account/positions` |
-| [getPositionsHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L495) | :closed_lock_with_key:  | GET | `/api/v5/account/positions-history` |
-| [getAccountPositionRisk()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L501) | :closed_lock_with_key:  | GET | `/api/v5/account/account-position-risk` |
-| [getBills()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L508) | :closed_lock_with_key:  | GET | `/api/v5/account/bills` |
-| [getBillsArchive()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L513) | :closed_lock_with_key:  | GET | `/api/v5/account/bills-archive` |
-| [getAccountBillSubtypes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L521) | :closed_lock_with_key:  | GET | `/api/v5/account/subtypes` |
-| [requestBillsHistoryDownloadLink()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L535) | :closed_lock_with_key:  | POST | `/api/v5/account/bills-history-archive` |
-| [getRequestedBillsHistoryLink()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L544) | :closed_lock_with_key:  | GET | `/api/v5/account/bills-history-archive` |
-| [getAccountConfiguration()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L550) | :closed_lock_with_key:  | GET | `/api/v5/account/config` |
-| [setPositionMode()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L554) | :closed_lock_with_key:  | POST | `/api/v5/account/set-position-mode` |
-| [setSettleCurrency()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L560) | :closed_lock_with_key:  | POST | `/api/v5/account/set-settle-currency` |
-| [setFeeType()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L566) | :closed_lock_with_key:  | POST | `/api/v5/account/set-fee-type` |
-| [setLeverage()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L570) | :closed_lock_with_key:  | POST | `/api/v5/account/set-leverage` |
-| [getMaxBuySellAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L575) | :closed_lock_with_key:  | GET | `/api/v5/account/max-size` |
-| [getMaxAvailableTradableAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L588) | :closed_lock_with_key:  | GET | `/api/v5/account/max-avail-size` |
-| [changePositionMargin()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L598) | :closed_lock_with_key:  | POST | `/api/v5/account/position/margin-balance` |
-| [getLeverage()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L604) | :closed_lock_with_key:  | GET | `/api/v5/account/leverage-info` |
-| [getLeverageV2()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L616) | :closed_lock_with_key:  | GET | `/api/v5/account/leverage-info` |
-| [getLeverageEstimatedInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L624) | :closed_lock_with_key:  | GET | `/api/v5/account/adjust-leverage-info` |
-| [getMaxLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L635) | :closed_lock_with_key:  | GET | `/api/v5/account/max-loan` |
-| [getFeeRates()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L644) | :closed_lock_with_key:  | GET | `/api/v5/account/trade-fee` |
-| [getInterestAccrued()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L655) | :closed_lock_with_key:  | GET | `/api/v5/account/interest-accrued` |
-| [getInterestRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L667) | :closed_lock_with_key:  | GET | `/api/v5/account/interest-rate` |
-| [setGreeksDisplayType()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L671) | :closed_lock_with_key:  | POST | `/api/v5/account/set-greeks` |
-| [setIsolatedMode()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L675) | :closed_lock_with_key:  | POST | `/api/v5/account/set-isolated-mode` |
-| [getMaxWithdrawals()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L682) | :closed_lock_with_key:  | GET | `/api/v5/account/max-withdrawal` |
-| [getAccountRiskState()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L686) | :closed_lock_with_key:  | GET | `/api/v5/account/risk-state` |
-| [setAccountCollateralAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L690) | :closed_lock_with_key:  | POST | `/api/v5/account/set-collateral-assets` |
-| [getAccountCollateralAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L704) | :closed_lock_with_key:  | GET | `/api/v5/account/collateral-assets` |
-| [submitQuickMarginBorrowRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L716) | :closed_lock_with_key:  | POST | `/api/v5/account/quick-margin-borrow-repay` |
-| [getQuickMarginBorrowRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L725) | :closed_lock_with_key:  | GET | `/api/v5/account/quick-margin-borrow-repay-history` |
-| [borrowRepayVIPLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L734) | :closed_lock_with_key:  | POST | `/api/v5/account/borrow-repay` |
-| [getVIPLoanBorrowRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L743) | :closed_lock_with_key:  | GET | `/api/v5/account/borrow-repay-history` |
-| [getVIPInterestAccrued()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L747) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-interest-accrued` |
-| [getVIPInterestDeducted()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L751) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-interest-deducted` |
-| [getVIPLoanOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L757) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-loan-order-list` |
-| [getVIPLoanOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L763) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-loan-order-detail` |
-| [getBorrowInterestLimits()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L769) | :closed_lock_with_key:  | GET | `/api/v5/account/interest-limits` |
-| [getFixedLoanBorrowLimit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L776) | :closed_lock_with_key:  | GET | `/api/v5/account/fixed-loan/borrowing-limit` |
-| [getFixedLoanBorrowQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L780) | :closed_lock_with_key:  | GET | `/api/v5/account/fixed-loan/borrowing-quote` |
-| [submitFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L789) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/borrowing-order` |
-| [updateFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L802) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/amend-borrowing-order` |
-| [manualRenewFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L815) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/manual-reborrow` |
-| [repayFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L829) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/repay-borrowing-order` |
-| [convertFixedLoanToMarketLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L840) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/convert-to-market-loan` |
-| [reduceFixedLoanLiabilities()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L851) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/reduce-liabilities` |
-| [getFixedLoanBorrowOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L866) | :closed_lock_with_key:  | GET | `/api/v5/account/fixed-loan/borrowing-orders-list` |
-| [manualBorrowRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L875) | :closed_lock_with_key:  | POST | `/api/v5/account/spot-manual-borrow-repay` |
-| [setAutoRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L889) | :closed_lock_with_key:  | POST | `/api/v5/account/set-auto-repay` |
-| [getBorrowRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L897) | :closed_lock_with_key:  | GET | `/api/v5/account/spot-borrow-repay-history` |
-| [positionBuilder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L903) | :closed_lock_with_key:  | POST | `/api/v5/account/position-builder` |
-| [updateRiskOffsetAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L907) | :closed_lock_with_key:  | POST | `/api/v5/account/set-riskOffset-amt` |
-| [getGreeks()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L919) | :closed_lock_with_key:  | GET | `/api/v5/account/greeks` |
-| [getPMLimitation()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L923) | :closed_lock_with_key:  | GET | `/api/v5/account/position-tiers` |
-| [updateRiskOffsetType()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L931) | :closed_lock_with_key:  | POST | `/api/v5/account/set-riskOffset-type` |
-| [activateOption()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L939) | :closed_lock_with_key:  | POST | `/api/v5/account/activate-option` |
-| [setAutoLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L947) | :closed_lock_with_key:  | POST | `/api/v5/account/set-auto-loan` |
-| [presetAccountLevelSwitch()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L951) | :closed_lock_with_key:  | POST | `/api/v5/account/account-level-switch-preset` |
-| [getAccountSwitchPrecheck()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L962) | :closed_lock_with_key:  | GET | `/api/v5/account/set-account-switch-precheck` |
-| [setAccountMode()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L971) | :closed_lock_with_key:  | POST | `/api/v5/account/set-account-level` |
-| [resetMMPStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L977) | :closed_lock_with_key:  | POST | `/api/v5/account/mmp-reset` |
-| [setMMPConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L985) | :closed_lock_with_key:  | POST | `/api/v5/account/mmp-config` |
-| [getMMPConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L989) | :closed_lock_with_key:  | GET | `/api/v5/account/mmp-config` |
-| [setTradingConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L993) | :closed_lock_with_key:  | POST | `/api/v5/account/set-trading-config` |
-| [precheckSetDeltaNeutral()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L999) | :closed_lock_with_key:  | GET | `/api/v5/account/precheck-set-delta-neutral` |
-| [submitOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1014) | :closed_lock_with_key:  | POST | `/api/v5/trade/order` |
-| [submitMultipleOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1018) | :closed_lock_with_key:  | POST | `/api/v5/trade/batch-orders` |
-| [cancelOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1022) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-order` |
-| [cancelMultipleOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1026) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-batch-orders` |
-| [amendOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1032) | :closed_lock_with_key:  | POST | `/api/v5/trade/amend-order` |
-| [amendMultipleOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1036) | :closed_lock_with_key:  | POST | `/api/v5/trade/amend-batch-orders` |
-| [closePositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1040) | :closed_lock_with_key:  | POST | `/api/v5/trade/close-position` |
-| [getOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1044) | :closed_lock_with_key:  | GET | `/api/v5/trade/order` |
-| [getOrderList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1048) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-pending` |
-| [getOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1055) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-history` |
-| [getOrderHistoryArchive()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1062) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-history-archive` |
-| [getFills()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1071) | :closed_lock_with_key:  | GET | `/api/v5/trade/fills` |
-| [getFillsHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1078) | :closed_lock_with_key:  | GET | `/api/v5/trade/fills-history` |
-| [getEasyConvertCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1083) | :closed_lock_with_key:  | GET | `/api/v5/trade/easy-convert-currency-list` |
-| [submitEasyConvert()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1096) | :closed_lock_with_key:  | POST | `/api/v5/trade/easy-convert` |
-| [getEasyConvertHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1105) | :closed_lock_with_key:  | GET | `/api/v5/trade/easy-convert-history` |
-| [getOneClickRepayCurrencyList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1114) | :closed_lock_with_key:  | GET | `/api/v5/trade/one-click-repay-currency-list` |
-| [submitOneClickRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1128) | :closed_lock_with_key:  | POST | `/api/v5/trade/one-click-repay` |
-| [getOneClickRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1136) | :closed_lock_with_key:  | GET | `/api/v5/trade/one-click-repay-history` |
-| [cancelMassOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1140) | :closed_lock_with_key:  | POST | `/api/v5/trade/mass-cancel` |
-| [cancelAllAfter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1152) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-all-after` |
-| [getAccountRateLimit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1159) | :closed_lock_with_key:  | GET | `/api/v5/trade/account-rate-limit` |
-| [submitOrderPrecheck()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1163) | :closed_lock_with_key:  | POST | `/api/v5/trade/order-precheck` |
-| [placeAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1173) | :closed_lock_with_key:  | POST | `/api/v5/trade/order-algo` |
-| [cancelAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1177) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-algos` |
-| [amendAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1183) | :closed_lock_with_key:  | POST | `/api/v5/trade/amend-algos` |
-| [cancelAdvanceAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1189) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-advance-algos` |
-| [getAlgoOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1195) | :closed_lock_with_key:  | GET | `/api/v5/trade/order-algo` |
-| [getAlgoOrderList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1201) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-algo-pending` |
-| [getAlgoOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1207) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-algo-history` |
-| [placeGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1219) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/order-algo` |
-| [amendGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1223) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/amend-order-algo` |
-| [stopGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1240) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/stop-order-algo` |
-| [closeGridContractPosition()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1244) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/close-position` |
-| [cancelGridContractCloseOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1250) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/cancel-close-order` |
-| [instantTriggerGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1260) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/order-instant-trigger` |
-| [getGridAlgoOrderList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1272) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/orders-algo-pending` |
-| [getGridAlgoOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1279) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/orders-algo-history` |
-| [getGridAlgoOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1286) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/orders-algo-details` |
-| [getGridAlgoSubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1296) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/sub-orders` |
-| [getGridAlgoOrderPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1308) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/positions` |
-| [spotGridWithdrawIncome()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1315) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/withdraw-income` |
-| [computeGridMarginBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1319) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/compute-margin-balance` |
-| [adjustGridMarginBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1330) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/margin-balance` |
-| [adjustGridInvestment()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1339) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/adjust-investment` |
-| [getGridAIParameter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1350) |  | GET | `/api/v5/tradingBot/grid/ai-param` |
-| [computeGridMinInvestment()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1359) |  | POST | `/api/v5/tradingBot/grid/min-investment` |
-| [getRSIBackTesting()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1366) |  | GET | `/api/v5/tradingBot/public/rsi-back-testing` |
-| [getMaxGridQuantity()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1374) |  | GET | `/api/v5/tradingBot/grid/grid-quantity` |
-| [createSignal()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1388) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/create-signal` |
-| [getSignals()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1392) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/signals` |
-| [createSignalBot()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1396) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/order-algo` |
-| [cancelSignalBots()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1402) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/stop-order-algo` |
-| [updateSignalMargin()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1411) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/margin-balance` |
-| [updateSignalTPSL()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1419) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/amendTPSL` |
-| [setSignalInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1427) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/set-instruments` |
-| [getSignalBotOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1438) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/orders-algo-details` |
-| [getActiveSignalBot()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1448) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/orders-algo-details` |
-| [getSignalBotHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1455) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/orders-algo-history` |
-| [getSignalBotPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1462) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/positions` |
-| [getSignalBotPositionHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1469) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/positions-history` |
-| [closeSignalBotPosition()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1478) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/close-position` |
-| [placeSignalBotSubOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1486) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/sub-order` |
-| [cancelSubOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1490) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/cancel-sub-order` |
-| [getSignalBotSubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1497) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/sub-orders` |
-| [getSignalBotEventHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1501) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/event-history` |
-| [submitRecurringBuyOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1513) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/recurring/order-algo` |
-| [amendRecurringBuyOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1519) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/recurring/amend-order-algo` |
-| [stopRecurringBuyOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1528) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/recurring/stop-order-algo` |
-| [getRecurringBuyOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1537) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/orders-algo-pending` |
-| [getRecurringBuyOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1546) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/orders-algo-history` |
-| [getRecurringBuyOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1555) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/orders-algo-details` |
-| [getRecurringBuySubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1564) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/sub-orders` |
-| [getCopytradingSubpositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1576) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/current-subpositions` |
-| [getCopytradingSubpositionsHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1582) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/subpositions-history` |
-| [submitCopytradingAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1588) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/algo-order` |
-| [closeCopytradingSubposition()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1594) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/close-subposition` |
-| [getCopytradingInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1603) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/instruments` |
-| [setCopytradingInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1612) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/set-instruments` |
-| [getCopytradingProfitDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1624) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/profit-sharing-details` |
-| [getCopytradingTotalProfit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1633) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/total-profit-sharing` |
-| [getCopytradingUnrealizedProfit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1639) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/unrealized-profit-sharing-details` |
-| [getCopytradingTotalUnrealizedProfit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1648) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/total-unrealized-profit-sharing` |
-| [applyCopytradingLeadTrading()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1660) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/apply-lead-trading` |
-| [stopCopytradingLeadTrading()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1671) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/stop-lead-trading` |
-| [updateCopytradingProfitSharing()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1679) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/amend-profit-sharing-ratio` |
-| [getCopytradingAccount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1693) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/config` |
-| [setCopytradingFirstCopy()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1697) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/first-copy-settings` |
-| [updateCopytradingCopySettings()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1705) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/amend-copy-settings` |
-| [stopCopytradingCopy()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1713) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/stop-copy-trading` |
-| [getCopytradingCopySettings()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1725) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/copy-settings` |
-| [getCopytradingBatchLeverageInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1732) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/batch-leverage-info` |
-| [setCopytradingBatchLeverage()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1738) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/batch-set-leverage` |
-| [getCopytradingMyLeadTraders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1744) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/current-lead-traders` |
-| [getCopytradingLeadTradersHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1750) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/lead-traders-history` |
-| [getCopytradingConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1756) |  | GET | `/api/v5/copytrading/public-config` |
-| [getCopytradingLeadRanks()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1762) |  | GET | `/api/v5/copytrading/public-lead-traders` |
-| [getCopytradingLeadWeeklyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1768) |  | GET | `/api/v5/copytrading/public-weekly-pnl` |
-| [getCopytradingLeadDailyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1775) |  | GET | `/api/v5/copytrading/public-pnl` |
-| [getCopytradingLeadStats()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1781) |  | GET | `/api/v5/copytrading/public-stats` |
-| [getCopytradingLeadPreferences()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1787) |  | GET | `/api/v5/copytrading/public-preference-currency` |
-| [getCopytradingLeadOpenPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1794) |  | GET | `/api/v5/copytrading/public-current-subpositions` |
-| [getCopytradingLeadPositionHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1800) |  | GET | `/api/v5/copytrading/public-subpositions-history` |
-| [getCopyTraders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1806) |  | GET | `/api/v5/copytrading/public-copy-traders` |
-| [getCopytradingLeadPrivateRanks()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1812) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/lead-traders` |
-| [getCopytradingLeadPrivateWeeklyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1818) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/weekly-pnl` |
-| [getCopytradingPLeadPrivateDailyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1825) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/pnl` |
-| [geCopytradingLeadPrivateStats()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1831) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/stats` |
-| [getCopytradingLeadPrivatePreferences()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1837) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/preference-currency` |
-| [getCopytradingLeadPrivateOpenPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1844) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/performance-current-subpositions` |
-| [getCopytradingLeadPrivatePositionHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1853) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/performance-subpositions-history` |
-| [getCopyTradersPrivate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1862) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/copy-traders` |
-| [getTickers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1874) |  | GET | `/api/v5/market/tickers` |
-| [getTicker()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1882) |  | GET | `/api/v5/market/ticker` |
-| [getOrderBook()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1886) |  | GET | `/api/v5/market/books` |
-| [getFullOrderBook()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1893) |  | GET | `/api/v5/market/books-full` |
-| [getCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1900) |  | GET | `/api/v5/market/candles` |
-| [getHistoricCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1904) |  | GET | `/api/v5/market/history-candles` |
-| [getTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1908) |  | GET | `/api/v5/market/trades` |
-| [getHistoricTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1912) |  | GET | `/api/v5/market/history-trades` |
-| [getOptionTradesByInstrument()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1922) |  | GET | `/api/v5/market/option/instrument-family-trades` |
-| [getOptionTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1928) |  | GET | `/api/v5/public/option-trades` |
-| [get24hrTotalVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1932) |  | GET | `/api/v5/market/platform-24-volume` |
-| [getBlockCounterParties()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1942) | :closed_lock_with_key:  | GET | `/api/v5/rfq/counterparties` |
-| [createBlockRFQ()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1946) | :closed_lock_with_key:  | POST | `/api/v5/rfq/create-rfq` |
-| [cancelBlockRFQ()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1950) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-rfq` |
-| [cancelMultipleBlockRFQs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1956) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-batch-rfqs` |
-| [cancelAllRFQs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1962) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-all-rfqs` |
-| [executeBlockQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1966) | :closed_lock_with_key:  | POST | `/api/v5/rfq/execute-quote` |
-| [getQuoteProducts()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1972) | :closed_lock_with_key:  | GET | `/api/v5/rfq/maker-instrument-settings` |
-| [updateBlockQuoteProducts()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1976) | :closed_lock_with_key:  | POST | `/api/v5/rfq/maker-instrument-settings` |
-| [resetBlockMmp()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1984) | :closed_lock_with_key:  | POST | `/api/v5/rfq/mmp-reset` |
-| [updateBlockMmpConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1992) | :closed_lock_with_key:  | POST | `/api/v5/rfq/mmp-config` |
-| [getBlockMmpConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1998) | :closed_lock_with_key:  | GET | `/api/v5/rfq/mmp-config` |
-| [createBlockQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2002) | :closed_lock_with_key:  | POST | `/api/v5/rfq/create-quote` |
-| [cancelBlockQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2008) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-quote` |
-| [cancelMultipleBlockQuotes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2014) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-batch-quotes` |
-| [cancelAllBlockQuotes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2020) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-all-quotes` |
-| [cancelAllBlockAfter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2024) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-all-after` |
-| [getBlockRFQs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2033) | :closed_lock_with_key:  | GET | `/api/v5/rfq/rfqs` |
-| [getBlockQuotes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2037) | :closed_lock_with_key:  | GET | `/api/v5/rfq/quotes` |
-| [getBlockTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2041) | :closed_lock_with_key:  | GET | `/api/v5/rfq/trades` |
-| [getPublicRFQBlockTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2045) |  | GET | `/api/v5/rfq/public-trades` |
-| [getBlockTickers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2049) |  | GET | `/api/v5/market/block-tickers` |
-| [getBlockTicker()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2056) |  | GET | `/api/v5/market/block-ticker` |
-| [getBlockPublicTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2060) |  | GET | `/api/v5/public/block-trades` |
-| [submitSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2072) | :closed_lock_with_key:  | POST | `/api/v5/sprd/order` |
-| [cancelSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2078) | :closed_lock_with_key:  | POST | `/api/v5/sprd/cancel-order` |
-| [cancelAllSpreadOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2085) | :closed_lock_with_key:  | POST | `/api/v5/sprd/mass-cancel` |
-| [updateSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2093) | :closed_lock_with_key:  | POST | `/api/v5/sprd/amend-order` |
-| [getSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2099) | :closed_lock_with_key:  | GET | `/api/v5/sprd/order` |
-| [getSpreadActiveOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2106) | :closed_lock_with_key:  | GET | `/api/v5/sprd/orders-pending` |
-| [getSpreadOrdersRecent()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2112) | :closed_lock_with_key:  | GET | `/api/v5/sprd/orders-history` |
-| [getSpreadOrdersArchive()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2118) | :closed_lock_with_key:  | GET | `/api/v5/sprd/orders-history-archive` |
-| [getSpreadTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2124) | :closed_lock_with_key:  | GET | `/api/v5/sprd/trades` |
-| [getSpreads()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2128) |  | GET | `/api/v5/sprd/spreads` |
-| [getSpreadOrderBook()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2132) |  | GET | `/api/v5/sprd/books` |
-| [getSpreadTicker()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2139) |  | GET | `/api/v5/market/sprd-ticker` |
-| [getSpreadPublicTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2143) |  | GET | `/api/v5/sprd/public-trades` |
-| [getSpreadCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2149) |  | GET | `/api/v5/market/sprd-candles` |
-| [getSpreadHistoryCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2153) |  | GET | `/api/v5/market/sprd-history-candles` |
-| [cancelSpreadAllAfter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2159) | :closed_lock_with_key:  | POST | `/api/v5/sprd/cancel-all-after` |
-| [getInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2174) |  | GET | `/api/v5/public/instruments` |
-| [getEventContractSeries()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2182) | :closed_lock_with_key:  | GET | `/api/v5/public/event-contract/series` |
-| [getEventContractEvents()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2192) | :closed_lock_with_key:  | GET | `/api/v5/public/event-contract/events` |
-| [getEventContractMarkets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2202) | :closed_lock_with_key:  | GET | `/api/v5/public/event-contract/markets` |
-| [getDeliveryExerciseHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2208) |  | GET | `/api/v5/public/delivery-exercise-history` |
-| [getOpenInterest()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2212) |  | GET | `/api/v5/public/open-interest` |
-| [getFundingRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2216) |  | GET | `/api/v5/public/funding-rate` |
-| [getFundingRateHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2220) |  | GET | `/api/v5/public/funding-rate-history` |
-| [getMinMaxLimitPrice()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2226) |  | GET | `/api/v5/public/price-limit` |
-| [getOptionMarketData()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2230) |  | GET | `/api/v5/public/opt-summary` |
-| [getEstimatedDeliveryExercisePrice()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2238) |  | GET | `/api/v5/public/estimated-price` |
-| [getDiscountRateAndInterestFreeQuota()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2244) |  | GET | `/api/v5/public/discount-rate-interest-free-quota` |
-| [getSystemTime()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2248) |  | GET | `/api/v5/public/time` |
-| [getHistoricalMarketData()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2252) |  | GET | `/api/v5/public/market-data-history` |
-| [getMarkPrice()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2258) |  | GET | `/api/v5/public/mark-price` |
-| [getPositionTiers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2262) |  | GET | `/api/v5/public/position-tiers` |
-| [getInterestRateAndLoanQuota()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2266) |  | GET | `/api/v5/public/interest-rate-loan-quota` |
-| [getVIPInterestRateAndLoanQuota()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2270) |  | GET | `/api/v5/public/vip-interest-rate-loan-quota` |
-| [getUnderlying()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2274) |  | GET | `/api/v5/public/underlying` |
-| [getInsuranceFund()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2278) |  | GET | `/api/v5/public/insurance-fund` |
-| [getUnitConvert()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2282) |  | GET | `/api/v5/public/convert-contract-coin` |
-| [getOptionTickBands()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2286) |  | GET | `/api/v5/public/instrument-tick-bands` |
-| [getPremiumHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2293) |  | GET | `/api/v5/public/premium-history` |
-| [getIndexTickers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2297) |  | GET | `/api/v5/market/index-tickers` |
-| [getIndexCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2304) |  | GET | `/api/v5/market/index-candles` |
-| [getHistoricIndexCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2308) |  | GET | `/api/v5/market/history-index-candles` |
-| [getMarkPriceCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2312) |  | GET | `/api/v5/market/mark-price-candles` |
-| [getHistoricMarkPriceCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2316) |  | GET | `/api/v5/market/history-mark-price-candles` |
-| [getOracle()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2322) |  | GET | `/api/v5/market/open-oracle` |
-| [getExchangeRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2326) |  | GET | `/api/v5/market/exchange-rate` |
-| [getIndexComponents()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2330) |  | GET | `/api/v5/market/index-components` |
-| [getEconomicCalendar()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2334) | :closed_lock_with_key:  | GET | `/api/v5/public/economic-calendar` |
-| [getPublicBlockTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2340) |  | GET | `/api/v5/market/block-trades` |
-| [getSupportCoin()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2350) |  | GET | `/api/v5/rubik/stat/trading-data/support-coin` |
-| [getOpenInterestHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2354) |  | GET | `/api/v5/rubik/stat/contracts/open-interest-history` |
-| [getTakerVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2363) |  | GET | `/api/v5/rubik/stat/taker-volume` |
-| [getContractTakerVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2373) |  | GET | `/api/v5/rubik/stat/taker-volume-contract` |
-| [getMarginLendingRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2379) |  | GET | `/api/v5/rubik/stat/margin/loan-ratio` |
-| [getTopTradersAccountRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2388) |  | GET | `/api/v5/rubik/stat/contracts/long-short-account-ratio-contract-top-trader` |
-| [getTopTradersContractPositionRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2397) |  | GET | `/api/v5/rubik/stat/contracts/long-short-position-ratio-contract-top-trader` |
-| [getLongShortContractRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2406) |  | GET | `/api/v5/rubik/stat/contracts/long-short-account-ratio-contract` |
-| [getLongShortRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2415) |  | GET | `/api/v5/rubik/stat/contracts/long-short-account-ratio` |
-| [getContractsOpenInterestAndVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2427) |  | GET | `/api/v5/rubik/stat/contracts/open-interest-volume` |
-| [getOptionsOpenInterestAndVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2439) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume` |
-| [getPutCallRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2446) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume-ratio` |
-| [getOpenInterestAndVolumeExpiry()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2456) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume-expiry` |
-| [getOpenInterestAndVolumeStrike()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2466) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume-strike` |
-| [getTakerFlow()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2477) |  | GET | `/api/v5/rubik/stat/option/taker-block-volume` |
-| [getCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2487) | :closed_lock_with_key:  | GET | `/api/v5/asset/currencies` |
-| [getBalances()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2491) | :closed_lock_with_key:  | GET | `/api/v5/asset/balances` |
-| [getNonTradableAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2495) | :closed_lock_with_key:  | GET | `/api/v5/asset/non-tradable-assets` |
-| [getAccountAssetValuation()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2499) | :closed_lock_with_key:  | GET | `/api/v5/asset/asset-valuation` |
-| [fundsTransfer()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2505) | :closed_lock_with_key:  | POST | `/api/v5/asset/transfer` |
-| [getFundsTransferState()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2510) | :closed_lock_with_key:  | GET | `/api/v5/asset/transfer-state` |
-| [getAssetBillsDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2521) | :closed_lock_with_key:  | GET | `/api/v5/asset/bills` |
-| [getAssetBillsHistoric()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2543) | :closed_lock_with_key:  | GET | `/api/v5/asset/bills-history` |
-| [getLightningDeposits()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2555) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-lightning` |
-| [getDepositAddress()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2563) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-address` |
-| [getDepositHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2567) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-history` |
-| [submitWithdraw()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2573) | :closed_lock_with_key:  | POST | `/api/v5/asset/withdrawal` |
-| [submitWithdrawLightning()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2577) | :closed_lock_with_key:  | POST | `/api/v5/asset/withdrawal-lightning` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2585) | :closed_lock_with_key:  | POST | `/api/v5/asset/cancel-withdrawal` |
-| [getWithdrawalHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2589) | :closed_lock_with_key:  | GET | `/api/v5/asset/withdrawal-history` |
-| [getDepositWithdrawStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2593) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-withdraw-status` |
-| [getExchanges()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2599) |  | GET | `/api/v5/asset/exchange-list` |
-| [applyForMonthlyStatement()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2603) | :closed_lock_with_key:  | POST | `/api/v5/asset/monthly-statement` |
-| [getMonthlyStatement()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2607) | :closed_lock_with_key:  | GET | `/api/v5/asset/monthly-statement` |
-| [getConvertCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2611) | :closed_lock_with_key:  | GET | `/api/v5/asset/convert/currencies` |
-| [getConvertCurrencyPair()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2615) | :closed_lock_with_key:  | GET | `/api/v5/asset/convert/currency-pair` |
-| [estimateConvertQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2624) | :closed_lock_with_key:  | POST | `/api/v5/asset/convert/estimate-quote` |
-| [convertTrade()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2628) | :closed_lock_with_key:  | POST | `/api/v5/asset/convert/trade` |
-| [getConvertHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2632) | :closed_lock_with_key:  | GET | `/api/v5/asset/convert/history` |
-| [getSubAccountList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2643) | :closed_lock_with_key:  | GET | `/api/v5/users/subaccount/list` |
-| [resetSubAccountAPIKey()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2647) | :closed_lock_with_key:  | POST | `/api/v5/users/subaccount/modify-apikey` |
-| [getSubAccountBalances()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2657) | :closed_lock_with_key:  | GET | `/api/v5/account/subaccount/balances` |
-| [getSubAccountFundingBalances()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2663) | :closed_lock_with_key:  | GET | `/api/v5/asset/subaccount/balances` |
-| [getSubAccountMaxWithdrawal()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2670) | :closed_lock_with_key:  | GET | `/api/v5/account/subaccount/max-withdrawal` |
-| [getSubAccountTransferHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2677) | :closed_lock_with_key:  | GET | `/api/v5/asset/subaccount/bills` |
-| [getManagedSubAccountTransferHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2688) | :closed_lock_with_key:  | GET | `/api/v5/asset/subaccount/managed-subaccount-bills` |
-| [transferSubAccountBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2698) | :closed_lock_with_key:  | POST | `/api/v5/asset/subaccount/transfer` |
-| [setSubAccountTransferOutPermission()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2704) | :closed_lock_with_key:  | POST | `/api/v5/users/subaccount/set-transfer-out` |
-| [getSubAccountCustodyTradingList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2714) | :closed_lock_with_key:  | GET | `/api/v5/users/entrust-subaccount-list` |
-| [setSubAccountLoanAllocation()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2720) | :closed_lock_with_key:  | POST | `/api/v5/account/subaccount/set-loan-allocation` |
-| [getSubAccountBorrowInterestAndLimit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2733) | :closed_lock_with_key:  | GET | `/api/v5/account/subaccount/interest-limits` |
-| [getStakingOffers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2750) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/offers` |
-| [submitStake()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2758) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/purchase` |
-| [redeemStake()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2769) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/redeem` |
-| [cancelStakingRequest()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2777) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/cancel` |
-| [getActiveStakingOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2785) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/orders-active` |
-| [getStakingOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2798) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/orders-history` |
-| [getETHStakingProductInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2818) |  | GET | `/api/v5/finance/staking-defi/eth/product-info` |
-| [getSOLStakingProductInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2822) |  | GET | `/api/v5/finance/staking-defi/sol/product-info` |
-| [purchaseETHStaking()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2826) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/eth/purchase` |
-| [redeemETHStaking()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2833) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/eth/redeem` |
-| [getETHStakingBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2837) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/eth/balance` |
-| [getETHStakingHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2841) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/eth/purchase-redeem-history` |
-| [cancelRedeemETHStaking()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2854) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/eth/cancel-redeem` |
-| [getAPYHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2865) |  | GET | `/api/v5/finance/staking-defi/eth/apy-history` |
-| [getSavingBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2875) | :closed_lock_with_key:  | GET | `/api/v5/finance/savings/balance` |
-| [savingsPurchaseRedemption()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2879) | :closed_lock_with_key:  | POST | `/api/v5/finance/savings/purchase-redempt` |
-| [setLendingRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2888) | :closed_lock_with_key:  | POST | `/api/v5/finance/savings/set-lending-rate` |
-| [getLendingHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2895) | :closed_lock_with_key:  | GET | `/api/v5/finance/savings/lending-history` |
-| [getPublicBorrowInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2899) |  | GET | `/api/v5/finance/savings/lending-rate-summary` |
-| [getPublicBorrowHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2903) |  | GET | `/api/v5/finance/savings/lending-rate-history` |
-| [getLendingOffers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2915) |  | GET | `/api/v5/finance/fixed-loan/lending-offers` |
-| [getLendingAPYHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2919) |  | GET | `/api/v5/finance/fixed-loan/lending-apy-history` |
-| [getLendingVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2923) |  | GET | `/api/v5/finance/fixed-loan/pending-lending-volume` |
-| [placeLendingOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2930) | :closed_lock_with_key:  | POST | `/api/v5/finance/fixed-loan/lending-order` |
-| [amendLendingOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2934) | :closed_lock_with_key:  | POST | `/api/v5/finance/fixed-loan/amend-lending-order` |
-| [getLendingOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2941) | :closed_lock_with_key:  | GET | `/api/v5/finance/fixed-loan/lending-orders-list` |
-| [getLendingSubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2948) | :closed_lock_with_key:  | GET | `/api/v5/finance/fixed-loan/lending-sub-orders` |
-| [getBorrowableCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2961) |  | GET | `/api/v5/finance/flexible-loan/borrow-currencies` |
-| [getCollateralAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2969) |  | GET | `/api/v5/finance/flexible-loan/collateral-assets` |
-| [getMaxLoanAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2975) | :closed_lock_with_key:  | POST | `/api/v5/finance/flexible-loan/max-loan` |
-| [adjustCollateral()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2979) | :closed_lock_with_key:  | POST | `/api/v5/finance/flexible-loan/adjust-collateral` |
-| [getLoanInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2986) | :closed_lock_with_key:  | GET | `/api/v5/finance/flexible-loan/loan-info` |
-| [getLoanHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2990) | :closed_lock_with_key:  | GET | `/api/v5/finance/flexible-loan/loan-history` |
-| [getAccruedInterest()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2997) | :closed_lock_with_key:  | GET | `/api/v5/finance/flexible-loan/interest-accrued` |
-| [getDcdCurrencyPairs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3013) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/currency-pair` |
-| [getDcdProducts()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3017) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/products` |
-| [requestDcdQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3021) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/quote` |
-| [submitDcdTrade()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3025) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/trade` |
-| [requestDcdRedeemQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3029) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/redeem-quote` |
-| [submitDcdRedeem()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3035) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/redeem` |
-| [getDcdOrderStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3039) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/order-status` |
-| [getDcdOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3045) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/order-history` |
-| [getStableRewardsProductInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3058) | :closed_lock_with_key:  | GET | `/api/v5/finance/stable-rewards/product-info` |
-| [requestStableRewardsQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3067) | :closed_lock_with_key:  | POST | `/api/v5/finance/stable-rewards/quote` |
-| [submitStableRewardsTrade()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3073) | :closed_lock_with_key:  | POST | `/api/v5/finance/stable-rewards/trade` |
-| [getStableRewardsBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3079) | :closed_lock_with_key:  | GET | `/api/v5/finance/stable-rewards/balance` |
-| [getStableRewardsApyHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3085) |  | GET | `/api/v5/finance/stable-rewards/apy-history` |
-| [getStableRewardsSubscribeRedeemHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3091) | :closed_lock_with_key:  | GET | `/api/v5/finance/stable-rewards/subscribe-redeem-history` |
-| [getAffiliatePerformanceSummary()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3107) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/performance/summary` |
-| [getInviteeDetail()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3113) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/invitee/detail` |
-| [getAffiliateInviteeList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3117) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/invitee/list` |
-| [getAffiliateLinkList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3123) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/link/list` |
-| [getAffiliateCoInviterLinkList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3129) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/co-inviter/list` |
-| [getAffiliateSubAffiliateList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3135) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/sub-affiliate/list` |
-| [getAffiliateRebateInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3141) | :closed_lock_with_key:  | GET | `/api/v5/users/partner/if-rebate` |
-| [getSystemStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3151) |  | GET | `/api/v5/system/status` |
-| [getAnnouncements()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3163) |  | GET | `/api/v5/support/announcements` |
-| [getAnnouncementTypes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3172) |  | GET | `/api/v5/support/announcement-types` |
-| [createSubAccount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3187) | :closed_lock_with_key:  | POST | `/api/v5/broker/nd/create-subaccount` |
-| [deleteSubAccount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3196) | :closed_lock_with_key:  | POST | `/api/v5/broker/nd/delete-subaccount` |
-| [createSubAccountAPIKey()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3200) | :closed_lock_with_key:  | POST | `/api/v5/broker/nd/subaccount/apikey` |
+| [getAccountInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L486) | :closed_lock_with_key:  | GET | `/api/v5/account/instruments` |
+| [getBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L492) | :closed_lock_with_key:  | GET | `/api/v5/account/balance` |
+| [getPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L496) | :closed_lock_with_key:  | GET | `/api/v5/account/positions` |
+| [getPositionsHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L500) | :closed_lock_with_key:  | GET | `/api/v5/account/positions-history` |
+| [getAccountPositionRisk()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L506) | :closed_lock_with_key:  | GET | `/api/v5/account/account-position-risk` |
+| [getBills()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L513) | :closed_lock_with_key:  | GET | `/api/v5/account/bills` |
+| [getBillsArchive()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L518) | :closed_lock_with_key:  | GET | `/api/v5/account/bills-archive` |
+| [getAccountBillSubtypes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L526) | :closed_lock_with_key:  | GET | `/api/v5/account/subtypes` |
+| [requestBillsHistoryDownloadLink()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L540) | :closed_lock_with_key:  | POST | `/api/v5/account/bills-history-archive` |
+| [getRequestedBillsHistoryLink()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L549) | :closed_lock_with_key:  | GET | `/api/v5/account/bills-history-archive` |
+| [getAccountConfiguration()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L555) | :closed_lock_with_key:  | GET | `/api/v5/account/config` |
+| [setPositionMode()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L559) | :closed_lock_with_key:  | POST | `/api/v5/account/set-position-mode` |
+| [setSettleCurrency()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L565) | :closed_lock_with_key:  | POST | `/api/v5/account/set-settle-currency` |
+| [setFeeType()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L571) | :closed_lock_with_key:  | POST | `/api/v5/account/set-fee-type` |
+| [setLeverage()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L575) | :closed_lock_with_key:  | POST | `/api/v5/account/set-leverage` |
+| [getMaxBuySellAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L580) | :closed_lock_with_key:  | GET | `/api/v5/account/max-size` |
+| [getMaxAvailableTradableAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L593) | :closed_lock_with_key:  | GET | `/api/v5/account/max-avail-size` |
+| [changePositionMargin()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L603) | :closed_lock_with_key:  | POST | `/api/v5/account/position/margin-balance` |
+| [movePositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L614) | :closed_lock_with_key:  | POST | `/api/v5/account/move-positions` |
+| [getMovePositionsHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L622) | :closed_lock_with_key:  | GET | `/api/v5/account/move-positions-history` |
+| [getLeverage()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L628) | :closed_lock_with_key:  | GET | `/api/v5/account/leverage-info` |
+| [getLeverageV2()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L640) | :closed_lock_with_key:  | GET | `/api/v5/account/leverage-info` |
+| [getLeverageEstimatedInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L648) | :closed_lock_with_key:  | GET | `/api/v5/account/adjust-leverage-info` |
+| [getMaxLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L659) | :closed_lock_with_key:  | GET | `/api/v5/account/max-loan` |
+| [getFeeRates()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L668) | :closed_lock_with_key:  | GET | `/api/v5/account/trade-fee` |
+| [getInterestAccrued()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L679) | :closed_lock_with_key:  | GET | `/api/v5/account/interest-accrued` |
+| [getInterestRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L691) | :closed_lock_with_key:  | GET | `/api/v5/account/interest-rate` |
+| [setGreeksDisplayType()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L695) | :closed_lock_with_key:  | POST | `/api/v5/account/set-greeks` |
+| [setIsolatedMode()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L699) | :closed_lock_with_key:  | POST | `/api/v5/account/set-isolated-mode` |
+| [getMaxWithdrawals()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L706) | :closed_lock_with_key:  | GET | `/api/v5/account/max-withdrawal` |
+| [getAccountRiskState()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L710) | :closed_lock_with_key:  | GET | `/api/v5/account/risk-state` |
+| [setAccountCollateralAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L714) | :closed_lock_with_key:  | POST | `/api/v5/account/set-collateral-assets` |
+| [getAccountCollateralAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L728) | :closed_lock_with_key:  | GET | `/api/v5/account/collateral-assets` |
+| [submitQuickMarginBorrowRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L740) | :closed_lock_with_key:  | POST | `/api/v5/account/quick-margin-borrow-repay` |
+| [getQuickMarginBorrowRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L749) | :closed_lock_with_key:  | GET | `/api/v5/account/quick-margin-borrow-repay-history` |
+| [borrowRepayVIPLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L758) | :closed_lock_with_key:  | POST | `/api/v5/account/borrow-repay` |
+| [getVIPLoanBorrowRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L767) | :closed_lock_with_key:  | GET | `/api/v5/account/borrow-repay-history` |
+| [getVIPInterestAccrued()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L771) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-interest-accrued` |
+| [getVIPInterestDeducted()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L775) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-interest-deducted` |
+| [getVIPLoanOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L781) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-loan-order-list` |
+| [getVIPLoanOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L787) | :closed_lock_with_key:  | GET | `/api/v5/account/vip-loan-order-detail` |
+| [getBorrowInterestLimits()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L793) | :closed_lock_with_key:  | GET | `/api/v5/account/interest-limits` |
+| [getFixedLoanBorrowLimit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L800) | :closed_lock_with_key:  | GET | `/api/v5/account/fixed-loan/borrowing-limit` |
+| [getFixedLoanBorrowQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L804) | :closed_lock_with_key:  | GET | `/api/v5/account/fixed-loan/borrowing-quote` |
+| [submitFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L813) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/borrowing-order` |
+| [updateFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L826) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/amend-borrowing-order` |
+| [manualRenewFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L839) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/manual-reborrow` |
+| [repayFixedLoanBorrowOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L853) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/repay-borrowing-order` |
+| [convertFixedLoanToMarketLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L864) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/convert-to-market-loan` |
+| [reduceFixedLoanLiabilities()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L875) | :closed_lock_with_key:  | POST | `/api/v5/account/fixed-loan/reduce-liabilities` |
+| [getFixedLoanBorrowOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L890) | :closed_lock_with_key:  | GET | `/api/v5/account/fixed-loan/borrowing-orders-list` |
+| [manualBorrowRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L899) | :closed_lock_with_key:  | POST | `/api/v5/account/spot-manual-borrow-repay` |
+| [setAutoRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L913) | :closed_lock_with_key:  | POST | `/api/v5/account/set-auto-repay` |
+| [getBorrowRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L921) | :closed_lock_with_key:  | GET | `/api/v5/account/spot-borrow-repay-history` |
+| [positionBuilder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L927) | :closed_lock_with_key:  | POST | `/api/v5/account/position-builder` |
+| [updateRiskOffsetAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L931) | :closed_lock_with_key:  | POST | `/api/v5/account/set-riskOffset-amt` |
+| [getGreeks()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L943) | :closed_lock_with_key:  | GET | `/api/v5/account/greeks` |
+| [getPMLimitation()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L947) | :closed_lock_with_key:  | GET | `/api/v5/account/position-tiers` |
+| [updateRiskOffsetType()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L955) | :closed_lock_with_key:  | POST | `/api/v5/account/set-riskOffset-type` |
+| [activateOption()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L963) | :closed_lock_with_key:  | POST | `/api/v5/account/activate-option` |
+| [setAutoLoan()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L971) | :closed_lock_with_key:  | POST | `/api/v5/account/set-auto-loan` |
+| [presetAccountLevelSwitch()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L975) | :closed_lock_with_key:  | POST | `/api/v5/account/account-level-switch-preset` |
+| [getAccountSwitchPrecheck()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L986) | :closed_lock_with_key:  | GET | `/api/v5/account/set-account-switch-precheck` |
+| [setAccountMode()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L995) | :closed_lock_with_key:  | POST | `/api/v5/account/set-account-level` |
+| [resetMMPStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1001) | :closed_lock_with_key:  | POST | `/api/v5/account/mmp-reset` |
+| [setMMPConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1009) | :closed_lock_with_key:  | POST | `/api/v5/account/mmp-config` |
+| [getMMPConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1013) | :closed_lock_with_key:  | GET | `/api/v5/account/mmp-config` |
+| [setTradingConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1017) | :closed_lock_with_key:  | POST | `/api/v5/account/set-trading-config` |
+| [precheckSetDeltaNeutral()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1023) | :closed_lock_with_key:  | GET | `/api/v5/account/precheck-set-delta-neutral` |
+| [submitOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1038) | :closed_lock_with_key:  | POST | `/api/v5/trade/order` |
+| [submitMultipleOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1042) | :closed_lock_with_key:  | POST | `/api/v5/trade/batch-orders` |
+| [cancelOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1046) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-order` |
+| [cancelMultipleOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1050) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-batch-orders` |
+| [amendOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1056) | :closed_lock_with_key:  | POST | `/api/v5/trade/amend-order` |
+| [amendMultipleOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1060) | :closed_lock_with_key:  | POST | `/api/v5/trade/amend-batch-orders` |
+| [closePositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1064) | :closed_lock_with_key:  | POST | `/api/v5/trade/close-position` |
+| [getOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1068) | :closed_lock_with_key:  | GET | `/api/v5/trade/order` |
+| [getOrderList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1072) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-pending` |
+| [getOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1079) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-history` |
+| [getOrderHistoryArchive()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1086) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-history-archive` |
+| [getFills()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1095) | :closed_lock_with_key:  | GET | `/api/v5/trade/fills` |
+| [getFillsHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1102) | :closed_lock_with_key:  | GET | `/api/v5/trade/fills-history` |
+| [getEasyConvertCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1107) | :closed_lock_with_key:  | GET | `/api/v5/trade/easy-convert-currency-list` |
+| [submitEasyConvert()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1120) | :closed_lock_with_key:  | POST | `/api/v5/trade/easy-convert` |
+| [getEasyConvertHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1129) | :closed_lock_with_key:  | GET | `/api/v5/trade/easy-convert-history` |
+| [getOneClickRepayCurrencyList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1138) | :closed_lock_with_key:  | GET | `/api/v5/trade/one-click-repay-currency-list` |
+| [submitOneClickRepay()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1152) | :closed_lock_with_key:  | POST | `/api/v5/trade/one-click-repay` |
+| [getOneClickRepayHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1160) | :closed_lock_with_key:  | GET | `/api/v5/trade/one-click-repay-history` |
+| [cancelMassOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1164) | :closed_lock_with_key:  | POST | `/api/v5/trade/mass-cancel` |
+| [cancelAllAfter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1176) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-all-after` |
+| [getAccountRateLimit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1183) | :closed_lock_with_key:  | GET | `/api/v5/trade/account-rate-limit` |
+| [submitOrderPrecheck()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1187) | :closed_lock_with_key:  | POST | `/api/v5/trade/order-precheck` |
+| [placeAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1197) | :closed_lock_with_key:  | POST | `/api/v5/trade/order-algo` |
+| [cancelAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1201) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-algos` |
+| [amendAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1207) | :closed_lock_with_key:  | POST | `/api/v5/trade/amend-algos` |
+| [cancelAdvanceAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1213) | :closed_lock_with_key:  | POST | `/api/v5/trade/cancel-advance-algos` |
+| [getAlgoOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1219) | :closed_lock_with_key:  | GET | `/api/v5/trade/order-algo` |
+| [getAlgoOrderList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1225) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-algo-pending` |
+| [getAlgoOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1231) | :closed_lock_with_key:  | GET | `/api/v5/trade/orders-algo-history` |
+| [placeGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1243) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/order-algo` |
+| [amendGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1247) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/amend-order-algo` |
+| [stopGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1264) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/stop-order-algo` |
+| [closeGridContractPosition()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1268) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/close-position` |
+| [cancelGridContractCloseOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1274) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/cancel-close-order` |
+| [instantTriggerGridAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1284) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/order-instant-trigger` |
+| [getGridAlgoOrderList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1296) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/orders-algo-pending` |
+| [getGridAlgoOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1303) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/orders-algo-history` |
+| [getGridAlgoOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1310) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/orders-algo-details` |
+| [getGridAlgoSubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1320) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/sub-orders` |
+| [getGridAlgoOrderPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1332) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/grid/positions` |
+| [spotGridWithdrawIncome()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1339) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/withdraw-income` |
+| [computeGridMarginBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1343) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/compute-margin-balance` |
+| [adjustGridMarginBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1354) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/margin-balance` |
+| [adjustGridInvestment()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1363) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/grid/adjust-investment` |
+| [getGridAIParameter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1374) |  | GET | `/api/v5/tradingBot/grid/ai-param` |
+| [computeGridMinInvestment()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1383) |  | POST | `/api/v5/tradingBot/grid/min-investment` |
+| [getRSIBackTesting()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1390) |  | GET | `/api/v5/tradingBot/public/rsi-back-testing` |
+| [getMaxGridQuantity()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1398) |  | GET | `/api/v5/tradingBot/grid/grid-quantity` |
+| [createSignal()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1412) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/create-signal` |
+| [getSignals()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1416) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/signals` |
+| [createSignalBot()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1420) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/order-algo` |
+| [cancelSignalBots()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1426) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/stop-order-algo` |
+| [updateSignalMargin()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1435) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/margin-balance` |
+| [updateSignalTPSL()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1443) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/amendTPSL` |
+| [setSignalInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1451) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/set-instruments` |
+| [getSignalBotOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1462) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/orders-algo-details` |
+| [getActiveSignalBot()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1472) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/orders-algo-details` |
+| [getSignalBotHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1479) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/orders-algo-history` |
+| [getSignalBotPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1486) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/positions` |
+| [getSignalBotPositionHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1493) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/positions-history` |
+| [closeSignalBotPosition()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1502) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/close-position` |
+| [placeSignalBotSubOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1510) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/sub-order` |
+| [cancelSubOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1514) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/signal/cancel-sub-order` |
+| [getSignalBotSubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1521) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/sub-orders` |
+| [getSignalBotEventHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1525) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/signal/event-history` |
+| [submitRecurringBuyOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1537) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/recurring/order-algo` |
+| [amendRecurringBuyOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1543) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/recurring/amend-order-algo` |
+| [stopRecurringBuyOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1552) | :closed_lock_with_key:  | POST | `/api/v5/tradingBot/recurring/stop-order-algo` |
+| [getRecurringBuyOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1561) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/orders-algo-pending` |
+| [getRecurringBuyOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1570) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/orders-algo-history` |
+| [getRecurringBuyOrderDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1579) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/orders-algo-details` |
+| [getRecurringBuySubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1588) | :closed_lock_with_key:  | GET | `/api/v5/tradingBot/recurring/sub-orders` |
+| [getCopytradingSubpositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1600) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/current-subpositions` |
+| [getCopytradingSubpositionsHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1606) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/subpositions-history` |
+| [submitCopytradingAlgoOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1612) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/algo-order` |
+| [closeCopytradingSubposition()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1618) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/close-subposition` |
+| [getCopytradingInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1627) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/instruments` |
+| [setCopytradingInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1636) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/set-instruments` |
+| [getCopytradingProfitDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1648) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/profit-sharing-details` |
+| [getCopytradingTotalProfit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1657) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/total-profit-sharing` |
+| [getCopytradingUnrealizedProfit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1663) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/unrealized-profit-sharing-details` |
+| [getCopytradingTotalUnrealizedProfit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1672) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/total-unrealized-profit-sharing` |
+| [applyCopytradingLeadTrading()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1684) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/apply-lead-trading` |
+| [stopCopytradingLeadTrading()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1695) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/stop-lead-trading` |
+| [updateCopytradingProfitSharing()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1703) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/amend-profit-sharing-ratio` |
+| [getCopytradingAccount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1717) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/config` |
+| [setCopytradingFirstCopy()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1721) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/first-copy-settings` |
+| [updateCopytradingCopySettings()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1729) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/amend-copy-settings` |
+| [stopCopytradingCopy()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1737) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/stop-copy-trading` |
+| [getCopytradingCopySettings()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1749) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/copy-settings` |
+| [getCopytradingBatchLeverageInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1756) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/batch-leverage-info` |
+| [setCopytradingBatchLeverage()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1762) | :closed_lock_with_key:  | POST | `/api/v5/copytrading/batch-set-leverage` |
+| [getCopytradingMyLeadTraders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1768) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/current-lead-traders` |
+| [getCopytradingLeadTradersHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1774) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/lead-traders-history` |
+| [getCopytradingConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1780) |  | GET | `/api/v5/copytrading/public-config` |
+| [getCopytradingLeadRanks()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1786) |  | GET | `/api/v5/copytrading/public-lead-traders` |
+| [getCopytradingLeadWeeklyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1792) |  | GET | `/api/v5/copytrading/public-weekly-pnl` |
+| [getCopytradingLeadDailyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1799) |  | GET | `/api/v5/copytrading/public-pnl` |
+| [getCopytradingLeadStats()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1805) |  | GET | `/api/v5/copytrading/public-stats` |
+| [getCopytradingLeadPreferences()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1811) |  | GET | `/api/v5/copytrading/public-preference-currency` |
+| [getCopytradingLeadOpenPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1818) |  | GET | `/api/v5/copytrading/public-current-subpositions` |
+| [getCopytradingLeadPositionHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1824) |  | GET | `/api/v5/copytrading/public-subpositions-history` |
+| [getCopyTraders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1830) |  | GET | `/api/v5/copytrading/public-copy-traders` |
+| [getCopytradingLeadPrivateRanks()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1836) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/lead-traders` |
+| [getCopytradingLeadPrivateWeeklyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1842) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/weekly-pnl` |
+| [getCopytradingPLeadPrivateDailyPnl()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1849) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/pnl` |
+| [geCopytradingLeadPrivateStats()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1855) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/stats` |
+| [getCopytradingLeadPrivatePreferences()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1861) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/preference-currency` |
+| [getCopytradingLeadPrivateOpenPositions()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1868) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/performance-current-subpositions` |
+| [getCopytradingLeadPrivatePositionHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1877) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/performance-subpositions-history` |
+| [getCopyTradersPrivate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1886) | :closed_lock_with_key:  | GET | `/api/v5/copytrading/copy-traders` |
+| [getTickers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1898) |  | GET | `/api/v5/market/tickers` |
+| [getTicker()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1906) |  | GET | `/api/v5/market/ticker` |
+| [getOrderBook()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1910) |  | GET | `/api/v5/market/books` |
+| [getFullOrderBook()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1917) |  | GET | `/api/v5/market/books-full` |
+| [getCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1924) |  | GET | `/api/v5/market/candles` |
+| [getHistoricCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1928) |  | GET | `/api/v5/market/history-candles` |
+| [getTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1932) |  | GET | `/api/v5/market/trades` |
+| [getHistoricTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1936) |  | GET | `/api/v5/market/history-trades` |
+| [getOptionTradesByInstrument()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1946) |  | GET | `/api/v5/market/option/instrument-family-trades` |
+| [getOptionTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1952) |  | GET | `/api/v5/public/option-trades` |
+| [get24hrTotalVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1956) |  | GET | `/api/v5/market/platform-24-volume` |
+| [getBlockCounterParties()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1966) | :closed_lock_with_key:  | GET | `/api/v5/rfq/counterparties` |
+| [createBlockRFQ()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1970) | :closed_lock_with_key:  | POST | `/api/v5/rfq/create-rfq` |
+| [cancelBlockRFQ()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1974) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-rfq` |
+| [cancelMultipleBlockRFQs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1980) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-batch-rfqs` |
+| [cancelAllRFQs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1986) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-all-rfqs` |
+| [executeBlockQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1990) | :closed_lock_with_key:  | POST | `/api/v5/rfq/execute-quote` |
+| [getQuoteProducts()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L1996) | :closed_lock_with_key:  | GET | `/api/v5/rfq/maker-instrument-settings` |
+| [updateBlockQuoteProducts()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2000) | :closed_lock_with_key:  | POST | `/api/v5/rfq/maker-instrument-settings` |
+| [resetBlockMmp()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2008) | :closed_lock_with_key:  | POST | `/api/v5/rfq/mmp-reset` |
+| [updateBlockMmpConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2016) | :closed_lock_with_key:  | POST | `/api/v5/rfq/mmp-config` |
+| [getBlockMmpConfig()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2022) | :closed_lock_with_key:  | GET | `/api/v5/rfq/mmp-config` |
+| [createBlockQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2026) | :closed_lock_with_key:  | POST | `/api/v5/rfq/create-quote` |
+| [cancelBlockQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2032) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-quote` |
+| [cancelMultipleBlockQuotes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2038) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-batch-quotes` |
+| [cancelAllBlockQuotes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2044) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-all-quotes` |
+| [cancelAllBlockAfter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2048) | :closed_lock_with_key:  | POST | `/api/v5/rfq/cancel-all-after` |
+| [getBlockRFQs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2057) | :closed_lock_with_key:  | GET | `/api/v5/rfq/rfqs` |
+| [getBlockQuotes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2061) | :closed_lock_with_key:  | GET | `/api/v5/rfq/quotes` |
+| [getBlockTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2065) | :closed_lock_with_key:  | GET | `/api/v5/rfq/trades` |
+| [getPublicRFQBlockTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2069) |  | GET | `/api/v5/rfq/public-trades` |
+| [getBlockTickers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2073) |  | GET | `/api/v5/market/block-tickers` |
+| [getBlockTicker()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2080) |  | GET | `/api/v5/market/block-ticker` |
+| [getBlockPublicTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2084) |  | GET | `/api/v5/public/block-trades` |
+| [submitSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2096) | :closed_lock_with_key:  | POST | `/api/v5/sprd/order` |
+| [cancelSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2102) | :closed_lock_with_key:  | POST | `/api/v5/sprd/cancel-order` |
+| [cancelAllSpreadOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2109) | :closed_lock_with_key:  | POST | `/api/v5/sprd/mass-cancel` |
+| [updateSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2117) | :closed_lock_with_key:  | POST | `/api/v5/sprd/amend-order` |
+| [getSpreadOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2123) | :closed_lock_with_key:  | GET | `/api/v5/sprd/order` |
+| [getSpreadActiveOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2130) | :closed_lock_with_key:  | GET | `/api/v5/sprd/orders-pending` |
+| [getSpreadOrdersRecent()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2136) | :closed_lock_with_key:  | GET | `/api/v5/sprd/orders-history` |
+| [getSpreadOrdersArchive()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2142) | :closed_lock_with_key:  | GET | `/api/v5/sprd/orders-history-archive` |
+| [getSpreadTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2148) | :closed_lock_with_key:  | GET | `/api/v5/sprd/trades` |
+| [getSpreads()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2152) |  | GET | `/api/v5/sprd/spreads` |
+| [getSpreadOrderBook()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2156) |  | GET | `/api/v5/sprd/books` |
+| [getSpreadTicker()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2163) |  | GET | `/api/v5/market/sprd-ticker` |
+| [getSpreadPublicTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2167) |  | GET | `/api/v5/sprd/public-trades` |
+| [getSpreadCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2173) |  | GET | `/api/v5/market/sprd-candles` |
+| [getSpreadHistoryCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2177) |  | GET | `/api/v5/market/sprd-history-candles` |
+| [cancelSpreadAllAfter()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2183) | :closed_lock_with_key:  | POST | `/api/v5/sprd/cancel-all-after` |
+| [getInstruments()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2198) |  | GET | `/api/v5/public/instruments` |
+| [getEventContractSeries()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2206) |  | GET | `/api/v5/public/event-contract/series` |
+| [getEventContractEvents()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2216) |  | GET | `/api/v5/public/event-contract/events` |
+| [getEventContractMarkets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2226) |  | GET | `/api/v5/public/event-contract/markets` |
+| [getDeliveryExerciseHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2232) |  | GET | `/api/v5/public/delivery-exercise-history` |
+| [getOpenInterest()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2236) |  | GET | `/api/v5/public/open-interest` |
+| [getFundingRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2240) |  | GET | `/api/v5/public/funding-rate` |
+| [getFundingRateHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2244) |  | GET | `/api/v5/public/funding-rate-history` |
+| [getMinMaxLimitPrice()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2250) |  | GET | `/api/v5/public/price-limit` |
+| [getOptionMarketData()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2254) |  | GET | `/api/v5/public/opt-summary` |
+| [getEstimatedDeliveryExercisePrice()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2262) |  | GET | `/api/v5/public/estimated-price` |
+| [getDiscountRateAndInterestFreeQuota()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2268) |  | GET | `/api/v5/public/discount-rate-interest-free-quota` |
+| [getSystemTime()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2272) |  | GET | `/api/v5/public/time` |
+| [getHistoricalMarketData()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2276) |  | GET | `/api/v5/public/market-data-history` |
+| [getMarkPrice()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2282) |  | GET | `/api/v5/public/mark-price` |
+| [getPositionTiers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2286) |  | GET | `/api/v5/public/position-tiers` |
+| [getInterestRateAndLoanQuota()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2290) |  | GET | `/api/v5/public/interest-rate-loan-quota` |
+| [getVIPInterestRateAndLoanQuota()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2294) |  | GET | `/api/v5/public/vip-interest-rate-loan-quota` |
+| [getUnderlying()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2298) |  | GET | `/api/v5/public/underlying` |
+| [getInsuranceFund()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2302) |  | GET | `/api/v5/public/insurance-fund` |
+| [getUnitConvert()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2306) |  | GET | `/api/v5/public/convert-contract-coin` |
+| [getOptionTickBands()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2310) |  | GET | `/api/v5/public/instrument-tick-bands` |
+| [getPremiumHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2317) |  | GET | `/api/v5/public/premium-history` |
+| [getIndexTickers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2321) |  | GET | `/api/v5/market/index-tickers` |
+| [getIndexCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2328) |  | GET | `/api/v5/market/index-candles` |
+| [getHistoricIndexCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2332) |  | GET | `/api/v5/market/history-index-candles` |
+| [getMarkPriceCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2336) |  | GET | `/api/v5/market/mark-price-candles` |
+| [getHistoricMarkPriceCandles()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2340) |  | GET | `/api/v5/market/history-mark-price-candles` |
+| [getOracle()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2346) |  | GET | `/api/v5/market/open-oracle` |
+| [getExchangeRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2350) |  | GET | `/api/v5/market/exchange-rate` |
+| [getIndexComponents()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2354) |  | GET | `/api/v5/market/index-components` |
+| [getEconomicCalendar()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2358) | :closed_lock_with_key:  | GET | `/api/v5/public/economic-calendar` |
+| [getPublicBlockTrades()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2364) |  | GET | `/api/v5/market/block-trades` |
+| [getSupportCoin()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2374) |  | GET | `/api/v5/rubik/stat/trading-data/support-coin` |
+| [getOpenInterestHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2378) |  | GET | `/api/v5/rubik/stat/contracts/open-interest-history` |
+| [getTakerVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2387) |  | GET | `/api/v5/rubik/stat/taker-volume` |
+| [getContractTakerVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2397) |  | GET | `/api/v5/rubik/stat/taker-volume-contract` |
+| [getMarginLendingRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2403) |  | GET | `/api/v5/rubik/stat/margin/loan-ratio` |
+| [getTopTradersAccountRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2412) |  | GET | `/api/v5/rubik/stat/contracts/long-short-account-ratio-contract-top-trader` |
+| [getTopTradersContractPositionRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2421) |  | GET | `/api/v5/rubik/stat/contracts/long-short-position-ratio-contract-top-trader` |
+| [getLongShortContractRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2430) |  | GET | `/api/v5/rubik/stat/contracts/long-short-account-ratio-contract` |
+| [getLongShortRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2439) |  | GET | `/api/v5/rubik/stat/contracts/long-short-account-ratio` |
+| [getContractsOpenInterestAndVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2451) |  | GET | `/api/v5/rubik/stat/contracts/open-interest-volume` |
+| [getOptionsOpenInterestAndVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2463) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume` |
+| [getPutCallRatio()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2470) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume-ratio` |
+| [getOpenInterestAndVolumeExpiry()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2480) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume-expiry` |
+| [getOpenInterestAndVolumeStrike()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2490) |  | GET | `/api/v5/rubik/stat/option/open-interest-volume-strike` |
+| [getTakerFlow()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2501) |  | GET | `/api/v5/rubik/stat/option/taker-block-volume` |
+| [getCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2511) | :closed_lock_with_key:  | GET | `/api/v5/asset/currencies` |
+| [getBalances()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2515) | :closed_lock_with_key:  | GET | `/api/v5/asset/balances` |
+| [getNonTradableAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2519) | :closed_lock_with_key:  | GET | `/api/v5/asset/non-tradable-assets` |
+| [getAccountAssetValuation()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2523) | :closed_lock_with_key:  | GET | `/api/v5/asset/asset-valuation` |
+| [fundsTransfer()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2529) | :closed_lock_with_key:  | POST | `/api/v5/asset/transfer` |
+| [getFundsTransferState()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2534) | :closed_lock_with_key:  | GET | `/api/v5/asset/transfer-state` |
+| [getAssetBillsDetails()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2545) | :closed_lock_with_key:  | GET | `/api/v5/asset/bills` |
+| [getAssetBillsHistoric()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2567) | :closed_lock_with_key:  | GET | `/api/v5/asset/bills-history` |
+| [getLightningDeposits()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2581) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-lightning` |
+| [getDepositAddress()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2589) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-address` |
+| [getDepositHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2593) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-history` |
+| [submitWithdraw()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2599) | :closed_lock_with_key:  | POST | `/api/v5/asset/withdrawal` |
+| [submitWithdrawLightning()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2603) | :closed_lock_with_key:  | POST | `/api/v5/asset/withdrawal-lightning` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2611) | :closed_lock_with_key:  | POST | `/api/v5/asset/cancel-withdrawal` |
+| [getWithdrawalHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2615) | :closed_lock_with_key:  | GET | `/api/v5/asset/withdrawal-history` |
+| [getDepositWithdrawStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2619) | :closed_lock_with_key:  | GET | `/api/v5/asset/deposit-withdraw-status` |
+| [getExchanges()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2625) |  | GET | `/api/v5/asset/exchange-list` |
+| [applyForMonthlyStatement()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2629) | :closed_lock_with_key:  | POST | `/api/v5/asset/monthly-statement` |
+| [getMonthlyStatement()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2633) | :closed_lock_with_key:  | GET | `/api/v5/asset/monthly-statement` |
+| [getConvertCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2637) | :closed_lock_with_key:  | GET | `/api/v5/asset/convert/currencies` |
+| [getConvertCurrencyPair()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2641) | :closed_lock_with_key:  | GET | `/api/v5/asset/convert/currency-pair` |
+| [estimateConvertQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2650) | :closed_lock_with_key:  | POST | `/api/v5/asset/convert/estimate-quote` |
+| [convertTrade()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2654) | :closed_lock_with_key:  | POST | `/api/v5/asset/convert/trade` |
+| [getConvertHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2658) | :closed_lock_with_key:  | GET | `/api/v5/asset/convert/history` |
+| [getSubAccountList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2669) | :closed_lock_with_key:  | GET | `/api/v5/users/subaccount/list` |
+| [resetSubAccountAPIKey()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2673) | :closed_lock_with_key:  | POST | `/api/v5/users/subaccount/modify-apikey` |
+| [getSubAccountBalances()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2683) | :closed_lock_with_key:  | GET | `/api/v5/account/subaccount/balances` |
+| [getSubAccountFundingBalances()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2689) | :closed_lock_with_key:  | GET | `/api/v5/asset/subaccount/balances` |
+| [getSubAccountMaxWithdrawal()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2696) | :closed_lock_with_key:  | GET | `/api/v5/account/subaccount/max-withdrawal` |
+| [getSubAccountTransferHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2703) | :closed_lock_with_key:  | GET | `/api/v5/asset/subaccount/bills` |
+| [getManagedSubAccountTransferHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2714) | :closed_lock_with_key:  | GET | `/api/v5/asset/subaccount/managed-subaccount-bills` |
+| [transferSubAccountBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2724) | :closed_lock_with_key:  | POST | `/api/v5/asset/subaccount/transfer` |
+| [setSubAccountTransferOutPermission()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2730) | :closed_lock_with_key:  | POST | `/api/v5/users/subaccount/set-transfer-out` |
+| [getSubAccountCustodyTradingList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2740) | :closed_lock_with_key:  | GET | `/api/v5/users/entrust-subaccount-list` |
+| [setSubAccountLoanAllocation()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2746) | :closed_lock_with_key:  | POST | `/api/v5/account/subaccount/set-loan-allocation` |
+| [getSubAccountBorrowInterestAndLimit()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2759) | :closed_lock_with_key:  | GET | `/api/v5/account/subaccount/interest-limits` |
+| [getStakingOffers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2776) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/offers` |
+| [submitStake()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2784) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/purchase` |
+| [redeemStake()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2795) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/redeem` |
+| [cancelStakingRequest()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2803) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/cancel` |
+| [getActiveStakingOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2811) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/orders-active` |
+| [getStakingOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2824) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/orders-history` |
+| [getETHStakingProductInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2844) |  | GET | `/api/v5/finance/staking-defi/eth/product-info` |
+| [getSOLStakingProductInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2848) |  | GET | `/api/v5/finance/staking-defi/sol/product-info` |
+| [purchaseETHStaking()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2852) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/eth/purchase` |
+| [redeemETHStaking()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2859) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/eth/redeem` |
+| [getETHStakingBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2863) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/eth/balance` |
+| [getETHStakingHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2867) | :closed_lock_with_key:  | GET | `/api/v5/finance/staking-defi/eth/purchase-redeem-history` |
+| [cancelRedeemETHStaking()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2880) | :closed_lock_with_key:  | POST | `/api/v5/finance/staking-defi/eth/cancel-redeem` |
+| [getAPYHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2891) |  | GET | `/api/v5/finance/staking-defi/eth/apy-history` |
+| [getSavingBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2901) | :closed_lock_with_key:  | GET | `/api/v5/finance/savings/balance` |
+| [savingsPurchaseRedemption()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2905) | :closed_lock_with_key:  | POST | `/api/v5/finance/savings/purchase-redempt` |
+| [setLendingRate()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2914) | :closed_lock_with_key:  | POST | `/api/v5/finance/savings/set-lending-rate` |
+| [getLendingHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2921) | :closed_lock_with_key:  | GET | `/api/v5/finance/savings/lending-history` |
+| [getPublicBorrowInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2925) |  | GET | `/api/v5/finance/savings/lending-rate-summary` |
+| [getPublicBorrowHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2929) |  | GET | `/api/v5/finance/savings/lending-rate-history` |
+| [getLendingOffers()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2941) |  | GET | `/api/v5/finance/fixed-loan/lending-offers` |
+| [getLendingAPYHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2945) |  | GET | `/api/v5/finance/fixed-loan/lending-apy-history` |
+| [getLendingVolume()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2949) |  | GET | `/api/v5/finance/fixed-loan/pending-lending-volume` |
+| [placeLendingOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2956) | :closed_lock_with_key:  | POST | `/api/v5/finance/fixed-loan/lending-order` |
+| [amendLendingOrder()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2960) | :closed_lock_with_key:  | POST | `/api/v5/finance/fixed-loan/amend-lending-order` |
+| [getLendingOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2967) | :closed_lock_with_key:  | GET | `/api/v5/finance/fixed-loan/lending-orders-list` |
+| [getLendingSubOrders()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2974) | :closed_lock_with_key:  | GET | `/api/v5/finance/fixed-loan/lending-sub-orders` |
+| [getBorrowableCurrencies()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2987) |  | GET | `/api/v5/finance/flexible-loan/borrow-currencies` |
+| [getCollateralAssets()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L2995) |  | GET | `/api/v5/finance/flexible-loan/collateral-assets` |
+| [getMaxLoanAmount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3001) | :closed_lock_with_key:  | POST | `/api/v5/finance/flexible-loan/max-loan` |
+| [adjustCollateral()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3005) | :closed_lock_with_key:  | POST | `/api/v5/finance/flexible-loan/adjust-collateral` |
+| [getLoanInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3012) | :closed_lock_with_key:  | GET | `/api/v5/finance/flexible-loan/loan-info` |
+| [getLoanHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3016) | :closed_lock_with_key:  | GET | `/api/v5/finance/flexible-loan/loan-history` |
+| [getAccruedInterest()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3023) | :closed_lock_with_key:  | GET | `/api/v5/finance/flexible-loan/interest-accrued` |
+| [getDcdCurrencyPairs()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3039) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/currency-pair` |
+| [getDcdProducts()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3043) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/products` |
+| [requestDcdQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3047) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/quote` |
+| [submitDcdTrade()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3051) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/trade` |
+| [requestDcdRedeemQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3055) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/redeem-quote` |
+| [submitDcdRedeem()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3061) | :closed_lock_with_key:  | POST | `/api/v5/finance/sfp/dcd/redeem` |
+| [getDcdOrderStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3065) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/order-status` |
+| [getDcdOrderHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3071) | :closed_lock_with_key:  | GET | `/api/v5/finance/sfp/dcd/order-history` |
+| [getStableRewardsProductInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3084) | :closed_lock_with_key:  | GET | `/api/v5/finance/stable-rewards/product-info` |
+| [requestStableRewardsQuote()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3093) | :closed_lock_with_key:  | POST | `/api/v5/finance/stable-rewards/quote` |
+| [submitStableRewardsTrade()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3099) | :closed_lock_with_key:  | POST | `/api/v5/finance/stable-rewards/trade` |
+| [getStableRewardsBalance()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3105) | :closed_lock_with_key:  | GET | `/api/v5/finance/stable-rewards/balance` |
+| [getStableRewardsApyHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3111) |  | GET | `/api/v5/finance/stable-rewards/apy-history` |
+| [getStableRewardsSubscribeRedeemHistory()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3117) | :closed_lock_with_key:  | GET | `/api/v5/finance/stable-rewards/subscribe-redeem-history` |
+| [getAffiliatePerformanceSummary()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3133) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/performance/summary` |
+| [getInviteeDetail()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3139) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/invitee/detail` |
+| [getAffiliateInviteeList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3143) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/invitee/list` |
+| [getAffiliateLinkList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3149) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/link/list` |
+| [getAffiliateCoInviterLinkList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3155) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/co-inviter/list` |
+| [getAffiliateSubAffiliateList()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3161) | :closed_lock_with_key:  | GET | `/api/v5/affiliate/sub-affiliate/list` |
+| [getAffiliateRebateInfo()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3167) | :closed_lock_with_key:  | GET | `/api/v5/users/partner/if-rebate` |
+| [getSystemStatus()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3177) |  | GET | `/api/v5/system/status` |
+| [getAnnouncements()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3189) |  | GET | `/api/v5/support/announcements` |
+| [getAnnouncementTypes()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3198) |  | GET | `/api/v5/support/announcement-types` |
+| [createSubAccount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3213) | :closed_lock_with_key:  | POST | `/api/v5/broker/nd/create-subaccount` |
+| [deleteSubAccount()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3222) | :closed_lock_with_key:  | POST | `/api/v5/broker/nd/delete-subaccount` |
+| [createSubAccountAPIKey()](https://github.com/tiagosiebler/okx-api/blob/master/src/rest-client.ts#L3226) | :closed_lock_with_key:  | POST | `/api/v5/broker/nd/subaccount/apikey` |
 
 # websocket-api-client.ts
 

--- a/examples/apidoc/RestClient/getEventContractMarkets.js
+++ b/examples/apidoc/RestClient/getEventContractMarkets.js
@@ -6,7 +6,7 @@ import { RestClient } from 'okx-api';
 // This OKX API SDK is available on npm via "npm install okx-api"
 // ENDPOINT: /api/v5/public/event-contract/markets
 // METHOD: GET
-// PUBLIC: NO
+// PUBLIC: YES
 
 const client = new RestClient({
     apiKey: 'apiKeyHere',

--- a/examples/apidoc/RestClient/getEventContractSeries.js
+++ b/examples/apidoc/RestClient/getEventContractSeries.js
@@ -6,7 +6,7 @@ import { RestClient } from 'okx-api';
 // This OKX API SDK is available on npm via "npm install okx-api"
 // ENDPOINT: /api/v5/public/event-contract/series
 // METHOD: GET
-// PUBLIC: NO
+// PUBLIC: YES
 
 const client = new RestClient({
     apiKey: 'apiKeyHere',

--- a/examples/apidoc/RestClient/getMovePositionsHistory.js
+++ b/examples/apidoc/RestClient/getMovePositionsHistory.js
@@ -4,9 +4,9 @@ import { RestClient } from 'okx-api';
 
 // This example shows how to call this OKX API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "okx-api" for OKX exchange
 // This OKX API SDK is available on npm via "npm install okx-api"
-// ENDPOINT: /api/v5/public/event-contract/events
+// ENDPOINT: /api/v5/account/move-positions-history
 // METHOD: GET
-// PUBLIC: YES
+// PUBLIC: NO
 
 const client = new RestClient({
     apiKey: 'apiKeyHere',
@@ -14,7 +14,7 @@ const client = new RestClient({
     apiPass: 'apiPassHere',
 });
 
-client.getEventContractEvents(params)
+client.getMovePositionsHistory(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/movePositions.js
+++ b/examples/apidoc/RestClient/movePositions.js
@@ -4,9 +4,9 @@ import { RestClient } from 'okx-api';
 
 // This example shows how to call this OKX API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "okx-api" for OKX exchange
 // This OKX API SDK is available on npm via "npm install okx-api"
-// ENDPOINT: /api/v5/public/event-contract/events
-// METHOD: GET
-// PUBLIC: YES
+// ENDPOINT: /api/v5/account/move-positions
+// METHOD: POST
+// PUBLIC: NO
 
 const client = new RestClient({
     apiKey: 'apiKeyHere',
@@ -14,7 +14,7 @@ const client = new RestClient({
     apiPass: 'apiPassHere',
 });
 
-client.getEventContractEvents(params)
+client.movePositions(params)
   .then((response) => {
     console.log(response);
   })

--- a/llms.txt
+++ b/llms.txt
@@ -49,8 +49,6 @@ Notes:
 Directory Structure
 ================================================================
 examples/
-  auth/
-    fasterHmacSign.ts
   Rest/
     app.okx.com.ts
     demo-trading.ts
@@ -2602,6 +2600,33 @@ export interface GetEventContractMarketsRequest {
   before?: string;
   after?: string;
 }
+⋮----
+/**
+ * @see GET /api/v5/public/insurance-fund (Get security fund)
+ * @see 2026-06-09 changelog — `regular_update` removed; `adl` and `platform_revenue` deprecated (return empty).
+ */
+export interface GetInsuranceFundRequest {
+  instType?: string;
+  /**
+   * `adl` and `platform_revenue` are deprecated and return empty values.
+   * `regular_update` was removed in 2026-06-09.
+   */
+  type?:
+    | 'liquidation_balance_deposit'
+    | 'bankruptcy_loss'
+    | 'platform_revenue'
+    | 'adl';
+  instFamily?: string;
+  ccy?: string;
+  before?: string;
+  after?: string;
+  limit?: string;
+}
+⋮----
+/**
+   * `adl` and `platform_revenue` are deprecated and return empty values.
+   * `regular_update` was removed in 2026-06-09.
+   */
 
 ================
 File: src/types/rest/request/stable-rewards.ts
@@ -3367,23 +3392,36 @@ export interface OrderResult {
   tag: string;
   ts: string;
   sCode: numberInString;
+  /** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+  subCode?: string;
   sMsg: string;
 }
+⋮----
+/** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
 ⋮----
 export interface CancelledOrderResult {
   clOrdId: string;
   ordId: string;
   sCode: string;
+  /** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+  subCode?: string;
   sMsg: string;
 }
+⋮----
+/** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
 ⋮----
 export interface AmendedOrder {
   clOrdId: string;
   ordId: string;
   reqId: string;
   sCode: string;
+  /** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+  subCode?: string;
   sMsg: string;
 }
+⋮----
+/** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+⋮----
 export interface ClosedPositions {
   instId: string;
   posSide: PositionSide;
@@ -3733,95 +3771,6 @@ export interface CancelAllAfterResponse {
 }
 
 ================
-File: src/types/rest/client.ts
-================
-import { APIMarket } from '../shared.js';
-⋮----
-export interface RestClientOptions {
-  apiKey?: string;
-  apiSecret?: string;
-  apiPass?: string;
-
-  /**
-   * The API group this client should connect to:
-   * - market: 'prod' (default: OKX Global REST at https://openapi.okx.com)
-   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
-   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
-   */
-  market?: APIMarket;
-
-  /**
-   * Set to `true` to use OKX's demo trading functionality
-   */
-  demoTrading?: boolean;
-
-  // Default: false. If true, we'll throw errors if any params are undefined
-  strict_param_validation?: boolean;
-
-  // Optionally override REST API base URL (e.g. 'https://www.okx.com' or 'https://openapi.okx.com').
-  // Note: to use my.okx or app.okx or eea.okx or us.okx, use the "market" parameter
-  // e.g 'https://eea.okx.com'
-  baseUrl?: string;
-
-  // Default: true. whether to try and post-process request exceptions.
-  parse_exceptions?: boolean;
-
-  /**
-   * Enable keep alive for REST API requests (via axios).
-   */
-  keepAlive?: boolean;
-
-  /**
-   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
-   * Only relevant if keepAlive is set to true.
-   * Default: 1000 (defaults comes from https agent)
-   */
-  keepAliveMsecs?: number;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-}
-⋮----
-/**
-   * The API group this client should connect to:
-   * - market: 'prod' (default: OKX Global REST at https://openapi.okx.com)
-   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
-   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
-   */
-⋮----
-/**
-   * Set to `true` to use OKX's demo trading functionality
-   */
-⋮----
-// Default: false. If true, we'll throw errors if any params are undefined
-⋮----
-// Optionally override REST API base URL (e.g. 'https://www.okx.com' or 'https://openapi.okx.com').
-// Note: to use my.okx or app.okx or eea.okx or us.okx, use the "market" parameter
-// e.g 'https://eea.okx.com'
-⋮----
-// Default: true. whether to try and post-process request exceptions.
-⋮----
-/**
-   * Enable keep alive for REST API requests (via axios).
-   */
-⋮----
-/**
-   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
-   * Only relevant if keepAlive is set to true.
-   * Default: 1000 (defaults comes from https agent)
-   */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-
-================
 File: src/types/websockets/ws-api-response.ts
 ================
 import { numberInString } from '../rest/shared.js';
@@ -3831,31 +3780,47 @@ export interface WSAPICancelOrderResultV5 {
   ordId: string;
   ts: numberInString;
   sCode: string;
+  /** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+  subCode?: string;
   sMsg: string;
 }
+⋮----
+/** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
 ⋮----
 export interface WSAPISpreadPlaceOrderResultV5 {
   clOrdId: string;
   ordId: string;
   tag: string;
   sCode: numberInString;
+  /** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+  subCode?: string;
   sMsg: string;
 }
+⋮----
+/** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
 ⋮----
 export interface WSAPISpreadAmendOrderResultV5 {
   clOrdId: string;
   ordId: string;
   reqId: string;
   sCode: string;
+  /** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+  subCode?: string;
   sMsg: string;
 }
+⋮----
+/** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
 ⋮----
 export interface WSAPISpreadCancelOrderResultV5 {
   clOrdId: string;
   ordId: string;
   sCode: string;
+  /** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
+  subCode?: string;
   sMsg: string;
 }
+⋮----
+/** Sub-code of sCode. Returns "" when sCode is 0. @see 2026-03-10 changelog */
 ⋮----
 /**
  * @see Ws public channel: estimated-price
@@ -4223,9 +4188,16 @@ export interface MessageEventLike {
 export function isMessageEvent(msg: unknown): msg is MessageEventLike
 ⋮----
 export interface WsEvent {
-  event: 'error' | 'login' | 'subscribe' | 'unsubscribe' | 'channel-conn-count';
+  event:
+    | 'error'
+    | 'login'
+    | 'subscribe'
+    | 'unsubscribe'
+    | 'channel-conn-count'
+    | 'notice';
   code?: string;
   msg?: string;
+  connId?: string;
   arg?: any;
   data?: any;
 }
@@ -4253,6 +4225,45 @@ export interface WsChannelConnInfoEvent extends WsEvent {
 }
 ⋮----
 export type WsResponse = WsEvent;
+⋮----
+/**
+ * Order book push for `books`, `books-l2-tbt`, `books50-l2-tbt`.
+ * @see 2026-06-23 changelog — `checksum` is deprecated (fixed to 0); use `seqId`/`prevSeqId` instead.
+ */
+export interface WsOrderBookLevel {
+  asks: [string, string, string, string][];
+  bids: [string, string, string, string][];
+  ts: string;
+  /** @deprecated Fixed to 0 — use seqId/prevSeqId for integrity verification */
+  checksum?: number;
+  prevSeqId?: number;
+  seqId?: number;
+}
+⋮----
+/** @deprecated Fixed to 0 — use seqId/prevSeqId for integrity verification */
+⋮----
+/**
+ * @see WS / ADL warning channel
+ * @see 2026-06-09 changelog — several fields return "" in warning/adl state; normal state no longer pushes.
+ */
+export interface WsAdlWarningData {
+  state: 'normal' | 'warning' | 'adl' | string;
+  ccy?: string;
+  maxBal?: string;
+  maxBalTs?: string;
+  adlType?: string;
+  adlBal?: string;
+  adlRecBal?: string;
+  decRate?: string;
+  /** @deprecated Returns "" per 2026-06-09 changelog */
+  adlRate?: string;
+  /** @deprecated Returns "" per 2026-06-09 changelog */
+  adlRecRate?: string;
+}
+⋮----
+/** @deprecated Returns "" per 2026-06-09 changelog */
+⋮----
+/** @deprecated Returns "" per 2026-06-09 changelog */
 
 ================
 File: src/types/websockets/ws-request.ts
@@ -4282,6 +4293,7 @@ export type WsPrivateChannel =
   | 'orders-algo'
   | 'algo-advance'
   | 'liquidation-warning'
+  | 'adl-warning'
   | 'account-greeks'
   | 'grid-orders-spot'
   | 'grid-orders-contract'
@@ -4563,38 +4575,6 @@ export type WsChannelSubUnSubRequestArg =
   | WsPublicChannelArgEventContractMarkets;
 
 ================
-File: src/types/shared.ts
-================
-export interface APICredentials {
-  apiKey: string;
-  apiSecret: string;
-  apiPass: string;
-}
-⋮----
-/**
- * The API Market represents the OKX Domain that you have signed up for. At this time, there are 3 supported domain groups:
- *
- * - GLOBAL, OKX Global (REST: openapi.okx.com; www.okx.com also works).
- * - EEA, otherwise known as "my.okx.com".
- * - US, otherwise known as "app.okx.com".
- */
-export type APIMarket =
-  | 'prod' // same as GLOBAL. Kept for some backwards compatibility
-  // OKX Global REST: https://openapi.okx.com (recommended). www.okx.com remains supported.
-  | 'GLOBAL'
-  // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
-  | 'EEA'
-  // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
-  | 'US';
-⋮----
-| 'prod' // same as GLOBAL. Kept for some backwards compatibility
-// OKX Global REST: https://openapi.okx.com (recommended). www.okx.com remains supported.
-⋮----
-// also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
-⋮----
-// also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
-
-================
 File: src/websocket-client-legacy.ts
 ================
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -4831,78 +4811,6 @@ function generateConfig(name)
 // The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
 ⋮----
 // Code is already transpiled from TypeScript, no additional loaders needed
-
-================
-File: examples/auth/fasterHmacSign.ts
-================
-import { createHmac } from 'crypto';
-⋮----
-import {
-  DefaultLogger,
-  RestClient,
-  WebsocketClient,
-} from '../../src/index.js';
-⋮----
-// or
-// import { createHmac } from 'crypto';
-// import { DefaultLogger, RestClient, WebsocketClient } from 'okx-api';
-⋮----
-/**
- * Injecting a custom signMessage function.
- *
- * As of version 3.0.0 of the okx-api Node.js/TypeScript/JavaScript
- * SDK for OKX, the SDK uses the Web Crypto API for signing requests.
- * While it is compatible with Node and Browser environments, it is
- * slightly slower than using Node's native crypto module (only
- * available in backend Node environments).
- *
- * For latency sensitive users, you can inject the previous node crypto sign
- * method (or your own even faster implementation), if this change affects you.
- *
- * This example demonstrates how to inject a custom sign function, to achieve
- * the same peformance as seen before the Web Crypto API was introduced.
- *
- * For context on standard usage, the "signMessage" function is used:
- * - During every single API call
- * - After opening a new private WebSocket connection
- */
-⋮----
-// If running from CLI in unix, you can pass env vars as such:
-// API_KEY_COM='lkm12n3-2ba3-1mxf-fn13-lkm12n3a' API_SECRET_COM='035B2B9637E1BDFFEE2646BFBDDB8CE4' API_PASSPHRASE_COM='ComplexPa$$!23$5^' ts-node examples/rest-private-trade.ts
-⋮----
-// note the single quotes, preventing special characters such as $ from being incorrectly passed
-⋮----
-// apiKey: 'apiKeyHere',
-⋮----
-// apiSecret: 'apiSecretHere',
-⋮----
-// apiPass: 'apiPassHere',
-/**
-   * Overkill in almost every case, but if you need any optimisation available,
-   * you can inject a faster sign mechanism such as node's native createHmac:
-   */
-⋮----
-// Optional, uncomment the "trace" override to log a lot more info about what the WS client is doing
-⋮----
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-// For private topics, include one or more accounts in an array. Otherwise only public topics will work
-⋮----
-/**
-     * Overkill in almost every case, but if you need any optimisation available,
-     * you can inject a faster sign mechanism such as node's native createHmac:
-     */
-⋮----
-function setWsClientEventListeners(
-  websocketClient: WebsocketClient,
-  accountRef: string,
-): Promise<void>
-⋮----
-// console.log('raw message received ', JSON.stringify(data, null, 2));
-⋮----
-// Simple promise to ensure we're subscribed before trying anything else
-⋮----
-// Start trading
 
 ================
 File: examples/Rest/rest-private-trade.ts
@@ -5400,6 +5308,97 @@ fromWdId: string; // Internal transfer initiator's withdrawal ID. If deposit com
 actualDepBlkConfirm: string; // The actual amount of blockchain confirmed in a single deposit
 
 ================
+File: src/types/rest/client.ts
+================
+import { APIMarket } from '../shared.js';
+⋮----
+export interface RestClientOptions {
+  apiKey?: string;
+  apiSecret?: string;
+  apiPass?: string;
+
+  /**
+   * The API group this client should connect to:
+   * - market: 'prod' (default: connects to OKX global) https://www.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'OPENAPI_GLOBAL' // OKX Global REST at https://openapi.okx.com
+   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
+   */
+  market?: APIMarket;
+
+  /**
+   * Set to `true` to use OKX's demo trading functionality
+   */
+  demoTrading?: boolean;
+
+  // Default: false. If true, we'll throw errors if any params are undefined
+  strict_param_validation?: boolean;
+
+  // Optionally override REST API base URL (e.g. 'https://www.okx.com' or 'https://openapi.okx.com').
+  // Note: to use my.okx or app.okx or eea.okx or us.okx, use the "market" parameter
+  // e.g 'https://eea.okx.com'
+  baseUrl?: string;
+
+  // Default: true. whether to try and post-process request exceptions.
+  parse_exceptions?: boolean;
+
+  /**
+   * Enable keep alive for REST API requests (via axios).
+   */
+  keepAlive?: boolean;
+
+  /**
+   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+   * Only relevant if keepAlive is set to true.
+   * Default: 1000 (defaults comes from https agent)
+   */
+  keepAliveMsecs?: number;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+}
+⋮----
+/**
+   * The API group this client should connect to:
+   * - market: 'prod' (default: connects to OKX global) https://www.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'OPENAPI_GLOBAL' // OKX Global REST at https://openapi.okx.com
+   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
+   */
+⋮----
+/**
+   * Set to `true` to use OKX's demo trading functionality
+   */
+⋮----
+// Default: false. If true, we'll throw errors if any params are undefined
+⋮----
+// Optionally override REST API base URL (e.g. 'https://www.okx.com' or 'https://openapi.okx.com').
+// Note: to use my.okx or app.okx or eea.okx or us.okx, use the "market" parameter
+// e.g 'https://eea.okx.com'
+⋮----
+// Default: true. whether to try and post-process request exceptions.
+⋮----
+/**
+   * Enable keep alive for REST API requests (via axios).
+   */
+⋮----
+/**
+   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+   * Only relevant if keepAlive is set to true.
+   * Default: 1000 (defaults comes from https agent)
+   */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+
+================
 File: src/types/rest/shared.ts
 ================
 export type numberInString<T = string> = T;
@@ -5517,104 +5516,41 @@ export type WithdrawState =
   | '12';
 
 ================
-File: src/types/websockets/ws-general.ts
+File: src/types/shared.ts
 ================
-import type { ClientRequestArgs } from 'http';
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { RestClientOptions } from '../rest/client.js';
-import { APICredentials, APIMarket } from '../shared.js';
-⋮----
-export interface WSClientConfigurableOptions {
-  accounts?: APICredentials[];
-
-  /**
-   * The API group this client should connect to:
-   * - market: 'prod' (default: connects to OKX global) https://www.okx.com/docs-v5/en/#overview-production-trading-services
-   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
-   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
-   */
-  market?: APIMarket;
-
-  /**
-   * Set to `true` to use OKX's demo trading functionality
-   */
-  demoTrading?: boolean;
-
-  // Disable ping/pong ws heartbeat mechanism (not recommended).
-  // Not supported for OKX
-  disableHeartbeat?: boolean;
-
-  /** How often to check if the connection is alive */
-  pingInterval?: number;
-
-  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-  pongTimeout?: number;
-
-  /** Delay in milliseconds before respawning the connection */
-  reconnectTimeout?: number;
-
-  requestOptions?: RestClientOptions;
-
-  wsOptions?: {
-    protocols?: string[];
-    agent?: any;
-  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
-  wsUrl?: string;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+export interface APICredentials {
+  apiKey: string;
+  apiSecret: string;
+  apiPass: string;
 }
 ⋮----
 /**
-   * The API group this client should connect to:
-   * - market: 'prod' (default: connects to OKX global) https://www.okx.com/docs-v5/en/#overview-production-trading-services
-   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
-   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
-   */
+ * The API Market represents the OKX Domain that you have signed up for. At this time, there are 4 supported domain groups:
+ *
+ * - GLOBAL, otherwise known as "www.okx.com".
+ * - OPENAPI_GLOBAL, OKX Global REST at openapi.okx.com (same WS as GLOBAL).
+ * - EEA, otherwise known as "my.okx.com".
+ * - US, otherwise known as "app.okx.com".
+ */
+export type APIMarket =
+  | 'prod' // same as GLOBAL. Kept for some backwards compatibility
+  // also known as "www.okx.com" or OKX Global: https://www.okx.com/docs-v5/en/#overview-production-trading-services
+  | 'GLOBAL'
+  // OKX Global REST at https://openapi.okx.com. WebSocket URLs unchanged (same as GLOBAL).
+  | 'OPENAPI_GLOBAL'
+  // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
+  | 'EEA'
+  // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
+  | 'US';
 ⋮----
-/**
-   * Set to `true` to use OKX's demo trading functionality
-   */
+| 'prod' // same as GLOBAL. Kept for some backwards compatibility
+// also known as "www.okx.com" or OKX Global: https://www.okx.com/docs-v5/en/#overview-production-trading-services
 ⋮----
-// Disable ping/pong ws heartbeat mechanism (not recommended).
-// Not supported for OKX
+// OKX Global REST at https://openapi.okx.com. WebSocket URLs unchanged (same as GLOBAL).
 ⋮----
-/** How often to check if the connection is alive */
+// also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
 ⋮----
-/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-⋮----
-/** Delay in milliseconds before respawning the connection */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-export interface WebsocketClientOptions extends WSClientConfigurableOptions {
-  market: APIMarket;
-  pongTimeout: number;
-  pingInterval: number;
-  reconnectTimeout: number;
-  authPrivateConnectionsOnConnect: boolean;
-  authPrivateRequests: boolean;
-
-  /**
-   * Whether to use native WebSocket ping/pong frames for heartbeats
-   */
-  useNativeHeartbeats: boolean;
-}
-⋮----
-/**
-   * Whether to use native WebSocket ping/pong frames for heartbeats
-   */
-⋮----
-export type WsEventInternalSrc = 'event' | 'function';
+// also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
 
 ================
 File: src/index.ts
@@ -6099,6 +6035,45 @@ export interface BillsHistoryArchiveRequest {
 }
 ⋮----
 /** Comma-separated bill type ids, e.g. 1,2,3. If omitted, all types. */
+⋮----
+export interface MovePositionLegFrom {
+  posId: string;
+  side: 'buy' | 'sell';
+  sz: string;
+}
+⋮----
+export interface MovePositionLegTo {
+  tdMode?: 'cross' | 'isolated';
+  posSide?: PositionSide;
+  ccy?: string;
+}
+⋮----
+export interface MovePositionLeg {
+  from: MovePositionLegFrom;
+  to: MovePositionLegTo;
+}
+⋮----
+/**
+ * @see POST /api/v5/account/move-positions
+ */
+export interface MovePositionsRequest {
+  fromAcct: string;
+  toAcct: string;
+  legs: MovePositionLeg[];
+  clientId: string;
+}
+⋮----
+/**
+ * @see GET /api/v5/account/move-positions-history
+ */
+export interface GetMovePositionsHistoryRequest {
+  blockTdId?: string;
+  clientId?: string;
+  beginTs?: string;
+  endTs?: string;
+  limit?: string;
+  state?: 'filled' | 'pending';
+}
 
 ================
 File: src/types/rest/request/funding.ts
@@ -6354,6 +6329,108 @@ export interface WSAPICancelSpreadOrderRequestV5 {
 export interface WSAPISpreadMassCancelOrdersRequestV5 {
   sprdId?: string;
 }
+
+================
+File: src/types/websockets/ws-general.ts
+================
+import type { ClientRequestArgs } from 'http';
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { RestClientOptions } from '../rest/client.js';
+import { APICredentials, APIMarket } from '../shared.js';
+⋮----
+export interface WSClientConfigurableOptions {
+  accounts?: APICredentials[];
+
+  /**
+   * The API group this client should connect to:
+   * - market: 'prod' (default: connects to OKX global) https://www.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'OPENAPI_GLOBAL' // OKX Global REST at https://openapi.okx.com (WS same as GLOBAL)
+   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
+   */
+  market?: APIMarket;
+
+  /**
+   * Set to `true` to use OKX's demo trading functionality
+   */
+  demoTrading?: boolean;
+
+  // Disable ping/pong ws heartbeat mechanism (not recommended).
+  // Not supported for OKX
+  disableHeartbeat?: boolean;
+
+  /** How often to check if the connection is alive */
+  pingInterval?: number;
+
+  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+  pongTimeout?: number;
+
+  /** Delay in milliseconds before respawning the connection */
+  reconnectTimeout?: number;
+
+  requestOptions?: RestClientOptions;
+
+  wsOptions?: {
+    protocols?: string[];
+    agent?: any;
+  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
+  wsUrl?: string;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+}
+⋮----
+/**
+   * The API group this client should connect to:
+   * - market: 'prod' (default: connects to OKX global) https://www.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'OPENAPI_GLOBAL' // OKX Global REST at https://openapi.okx.com (WS same as GLOBAL)
+   * - market: 'EEA' // also known as "my.okx.com" https://my.okx.com/docs-v5/en/#overview-production-trading-services
+   * - market: 'US' // also known as "app.okx.com" https://app.okx.com/docs-v5/en/#overview-production-trading-services
+   */
+⋮----
+/**
+   * Set to `true` to use OKX's demo trading functionality
+   */
+⋮----
+// Disable ping/pong ws heartbeat mechanism (not recommended).
+// Not supported for OKX
+⋮----
+/** How often to check if the connection is alive */
+⋮----
+/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+⋮----
+/** Delay in milliseconds before respawning the connection */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+export interface WebsocketClientOptions extends WSClientConfigurableOptions {
+  market: APIMarket;
+  pongTimeout: number;
+  pingInterval: number;
+  reconnectTimeout: number;
+  authPrivateConnectionsOnConnect: boolean;
+  authPrivateRequests: boolean;
+
+  /**
+   * Whether to use native WebSocket ping/pong frames for heartbeats
+   */
+  useNativeHeartbeats: boolean;
+}
+⋮----
+/**
+   * Whether to use native WebSocket ping/pong frames for heartbeats
+   */
+⋮----
+export type WsEventInternalSrc = 'event' | 'function';
 
 ================
 File: src/websocket-client.ts
@@ -6683,661 +6760,6 @@ type DeferredWSAPIResponse = TWSAPIResponse & {
 // Return deferred promise, so caller can await this call
 
 ================
-File: src/types/rest/response/private-account.ts
-================
-import {
-  AccountLevel,
-  MarginMode,
-  PositionSide,
-  WithdrawState,
-} from '../shared.js';
-import type { InstrumentUpcomingParamChange } from './public-data.js';
-⋮----
-export interface AccountBalanceDetail {
-  availBal: string;
-  availEq: string;
-  cashBal: string;
-  ccy: string;
-  crossLiab: string;
-  disEq: string;
-  eq: string;
-  eqUsd: string;
-  frozenBal: string;
-  interest: string;
-  isoEq: string;
-  isoLiab: string;
-  isoUpl: string;
-  liab: string;
-  maxLoan: string;
-  mgnRatio: string;
-  notionalLever: string;
-  ordFrozen: string;
-  twap: string;
-  uTime: string;
-  upl: string;
-  uplLiab: string;
-  stgyEq: string;
-  spotBal: string; // Spot balance. The unit is currency, e.g. BTC.
-  openAvgPx: string[]; // Spot average cost price. The unit is USD.
-  accAvgPx: string[]; // Spot accumulated cost price. The unit is USD.
-  spotUpl: string; // Spot unrealized profit and loss. The unit is USD.
-  spotUplRatio: string; // Spot unrealized profit and loss ratio.
-  totalPnl: string; // Spot accumulated profit and loss. The unit is USD.
-  totalPnlRatio: string; // Spot accumulated profit and loss ratio.
-}
-⋮----
-spotBal: string; // Spot balance. The unit is currency, e.g. BTC.
-openAvgPx: string[]; // Spot average cost price. The unit is USD.
-accAvgPx: string[]; // Spot accumulated cost price. The unit is USD.
-spotUpl: string; // Spot unrealized profit and loss. The unit is USD.
-spotUplRatio: string; // Spot unrealized profit and loss ratio.
-totalPnl: string; // Spot accumulated profit and loss. The unit is USD.
-totalPnlRatio: string; // Spot accumulated profit and loss ratio.
-⋮----
-export interface AccountBalance {
-  adjEq: string;
-  details: AccountBalanceDetail[];
-  imr: string;
-  isoEq: string;
-  mgnRatio: string;
-  mmr: string;
-  notionalUsd: string;
-  notionalUsdForBorrow: string;
-  notionalUsdForFutures: string;
-  notionalUsdForOption: string;
-  notionalUsdForSwap: string;
-  ordFroz: string;
-  totalEq: string;
-  uTime: string;
-  spotCopyTradingEq: string;
-  upl: string;
-  frpType?: string;
-  // Delta neutral strategy fields
-  delta: string; // Delta (USD)
-  deltaLever: string; // Delta neutral strategy account level delta leverage (deltaLever = delta / totalEq)
-  deltaNeutralStatus: string; // Delta risk status: 0=normal, 1=transfer restricted, 2=delta reducing
-}
-⋮----
-// Delta neutral strategy fields
-delta: string; // Delta (USD)
-deltaLever: string; // Delta neutral strategy account level delta leverage (deltaLever = delta / totalEq)
-deltaNeutralStatus: string; // Delta risk status: 0=normal, 1=transfer restricted, 2=delta reducing
-⋮----
-export interface AccountPosition {
-  adl: string;
-  availPos: string;
-  avgPx: string;
-  cTime: string;
-  ccy: string;
-  deltaBS: string;
-  deltaPA: string;
-  gammaBS: string;
-  gammaPA: string;
-  imr: string;
-  instId: string;
-  instType: string;
-  interest: string;
-  usdPx: string;
-  last: string;
-  lever: string;
-  liab: string;
-  liabCcy: string;
-  liqPx: string;
-  markPx: string;
-  margin: string;
-  mgnMode: MarginMode;
-  mgnRatio: string;
-  mmr: string;
-  notionalUsd: string;
-  optVal: string;
-  pTime: string;
-  pos: string;
-  hedgedPos: string; // Hedged position size. Only returned for accounts in delta neutral strategy (stgyType:1). Returns "" for accounts in general strategy.
-  posCcy: string;
-  posId: string;
-  posSide: PositionSide;
-  thetaBS: string;
-  thetaPA: string;
-  tradeId: string;
-  uTime: string;
-  upl: string;
-  uplRatio: string;
-  vegaBS: string;
-  vegaPA: string;
-}
-⋮----
-hedgedPos: string; // Hedged position size. Only returned for accounts in delta neutral strategy (stgyType:1). Returns "" for accounts in general strategy.
-⋮----
-export interface HistoricAccountPosition {
-  cTime: string;
-  ccy: string;
-  closeAvgPx: string;
-  closeTotalPos: string;
-  instId: string;
-  instType: string;
-  lever: string;
-  mgnMode: MarginMode;
-  openAvgPx: string;
-  openMaxPos: string;
-  pnl: string;
-  pnlRatio: string;
-  posId: string;
-  posSide: PositionSide;
-  triggerPx: string;
-  type: string;
-  uTime: string;
-  uly: string;
-}
-⋮----
-export interface AccountBalanceRiskData {
-  ccy: string;
-  disEq: string;
-  eq: string;
-}
-⋮----
-export interface AccountPositionRiskData {
-  baseBal: string;
-  ccy: string;
-  instId: string;
-  instType: string;
-  mgnMode: MarginMode;
-  notionalCcy: string;
-  notionalUsd: string;
-  pos: string;
-  posCcy: string;
-  posId: string;
-  posSide: PositionSide;
-  quoteBal: string;
-}
-⋮----
-export interface AccountPositionRisk {
-  adjEq: string;
-  balData: AccountBalanceRiskData[];
-  posData: AccountPositionRiskData[];
-  ts: string;
-}
-⋮----
-export interface AccountBill {
-  bal: string;
-  balChg: string;
-  billId: string;
-  ccy: string;
-  execType: string;
-  fee: string;
-  from: string;
-  instId: string;
-  instType: string;
-  mgnMode: MarginMode;
-  notes: string;
-  ordId: string;
-  pnl: string;
-  posBal: string;
-  posBalChg: string;
-  subType: string;
-  sz: string;
-  to: string;
-  ts: string;
-  type: string;
-  earnAmt?: string;
-  earnApr?: string;
-}
-⋮----
-export interface BillSubTypeDetail {
-  subType: string;
-  subTypeDesc: string;
-}
-⋮----
-/**
- * @see GET /api/v5/account/subtypes
- */
-export interface AccountBillTypeDefinition {
-  type: string;
-  typeDesc: string;
-  subTypeDetails: BillSubTypeDetail[];
-}
-⋮----
-/**
- * Apply (POST) may return { result, ts }; get link (GET) may return { fileHref, state, ts }.
- */
-export interface AccountHistoryBill {
-  fileHref?: string;
-  result?: string;
-  state?: 'finished' | 'ongoing' | 'failed' | string;
-  ts: string;
-}
-⋮----
-export interface AccountConfiguration {
-  acctLv: string;
-  autoLoan: boolean;
-  ctIsoMode: string;
-  greeksType: string;
-  level: string;
-  levelTmp: string;
-  mgnIsoMode: string;
-  posMode: string;
-  spotOffsetType: string;
-  stgyType: string; // Strategy type: 0=general strategy, 1=delta neutral strategy
-  uid: string;
-  label: string;
-  roleType: string;
-  traderInsts: any[];
-  spotRoleType: string;
-  spotTraderInsts: any[];
-  opAuth: string;
-  kycLv: string;
-  ip: string;
-  perm: string;
-  mainUid: string;
-  discountType: '0' | '1';
-  enableSpotBorrow: boolean;
-  spotBorrowAutoRepay: boolean;
-  feeType: string;
-  settleCcy: string;
-  settleCcyList: string[];
-}
-⋮----
-stgyType: string; // Strategy type: 0=general strategy, 1=delta neutral strategy
-⋮----
-export interface AccountPositionModeResult {
-  posMode: string;
-}
-⋮----
-export interface AccountModeResult {
-  acctLv: AccountLevel;
-}
-⋮----
-export interface AutoLoanResult {
-  autoLoan: boolean;
-}
-⋮----
-export interface AccountLeverageResult {
-  lever: string;
-  mgnMode: MarginMode;
-  instId: string;
-  posSide: PositionSide;
-}
-⋮----
-export interface AccountMaxOrderAmount {
-  ccy: string;
-  instId: string;
-  maxBuy: string;
-  maxSell: string;
-}
-⋮----
-export interface AccountMaxTradableAmount {
-  instId: string;
-  availBuy: string;
-  availSell: string;
-}
-⋮----
-export interface AccountChangeMarginResult {
-  amt: string;
-  ccy: string;
-  instId: string;
-  leverage: string;
-  posSide: PositionSide;
-  type: string;
-}
-⋮----
-export interface AccountLeverage {
-  instId: string;
-  mgnMode: MarginMode;
-  posSide: PositionSide;
-  lever: string;
-}
-⋮----
-export interface AccountMaxLoan {
-  instId: string;
-  mgnMode: MarginMode;
-  mgnCcy: string;
-  maxLoan: string;
-  ccy: string;
-  side: string;
-}
-⋮----
-export interface FeeGroup {
-  taker: string;
-  maker: string;
-  groupId: string;
-}
-⋮----
-export interface AccountFeeRate {
-  category: never;
-  delivery: string;
-  exercise: string;
-  instType: string;
-  level: string;
-  maker: string;
-  makerU: string;
-  taker: string;
-  takerU: string;
-  settle?: string;
-  ts: string;
-  ruleType: string;
-  feeGroup?: FeeGroup[]; // Fee groups. Applicable to SPOT/MARGIN/SWAP/FUTURES/OPTION
-}
-⋮----
-feeGroup?: FeeGroup[]; // Fee groups. Applicable to SPOT/MARGIN/SWAP/FUTURES/OPTION
-⋮----
-export interface AccountIsolatedMode {
-  isoMode: 'autonomy' | 'automatic';
-}
-⋮----
-export interface AdjustLeverageInfo {
-  estAvailQuoteTrans: string;
-  estAvailTrans: string;
-  estLiqPx: string;
-  estMgn: string;
-  estQuoteMgn: string;
-  estMaxAmt: string;
-  estQuoteMaxAmt: string;
-  existOrd: boolean;
-  maxLever: string;
-  minLever: string;
-}
-⋮----
-export interface InterestAccrued {
-  type: '1' | '2';
-  ccy: string;
-  instId: string;
-  mgnMode: MarginMode;
-  interest: string;
-  interestRate: string;
-  liab: string;
-  ts: string;
-}
-⋮----
-export interface InterestRate {
-  interestRate: string;
-  ccy: string;
-}
-⋮----
-export interface Greeks {
-  greeksType: string;
-}
-⋮----
-export interface MaxWithdrawal {
-  ccy: string;
-  maxWd: string;
-  maxWdEx: string;
-  spotOffsetMaxWd: string;
-  spotOffsetMaxWdEx: string;
-}
-⋮----
-export interface AccountRiskState {
-  atRisk: string;
-  atRiskIdx: string;
-  atRiskMgn: string;
-  ts: string;
-}
-⋮----
-export interface WithdrawalHistory {
-  ccy: string;
-  chain: string;
-  nonTradableAsset: boolean;
-  amt: string;
-  ts: string;
-  from: string;
-  areaCodeFrom: string;
-  to: string;
-  areaCodeTo: string;
-  tag: string;
-  pmtId: string;
-  memo: string;
-  addrExt: any;
-  txId: string;
-  fee: string;
-  feeCcy: string;
-  state: WithdrawState;
-  wdId: string;
-  clientId: string;
-}
-⋮----
-export interface AccountInstrument {
-  baseCcy: string;
-  ctMult: string;
-  ctType: string;
-  ctVal: string;
-  ctValCcy: string;
-  expTime: string;
-  instFamily: string;
-  instId: string;
-  instType: string;
-  seriesId?: string;
-  uly?: string;
-  /**
-   * FUTURES label (deprecated � prefer `expTime`; may include this_five_years, next_five_years, �).
-   */
-  alias?: string;
-  /** Deprecated; see `instCategory` on public `Instrument` where used. */
-  category?: string;
-  lever: string;
-  listTime: string;
-  contTdSwTime: string; // Continuous trading switch time. The switch time from call auction/prequote to continuous trading. Unix timestamp format in milliseconds.
-  preMktSwTime: string; // The time premarket swap switched to normal swap. Unix timestamp format in milliseconds. Only applicable to premarket SWAP.
-  lotSz: string;
-  maxIcebergSz: string;
-  maxLmtAmt: string;
-  maxLmtSz: string;
-  maxMktAmt: string;
-  maxMktSz: string;
-  maxStopSz: string;
-  maxTriggerSz: string;
-  maxTwapSz: string;
-  minSz: string;
-  optType: string;
-  openType: string; // Open type: fix_price (fix price opening), pre_quote (pre-quote), call_auction (call auction). Only applicable to SPOT/MARGIN.
-  quoteCcy: string;
-  tradeQuoteCcyList: string[]; // List of quote currencies available for trading, e.g. ["USD", "USDC"]
-  settleCcy: string;
-  /** Instrument status: live, suspend, rebase (SWAP only), post_only (SWAP only), preopen, test */
-  state: string;
-  stk: string;
-  tickSz: string;
-  /** Trading rule types: normal, pre_market, rebase_contract */
-  ruleType: string;
-  auctionEndTime: string;
-  futureSettlement: boolean; // Whether daily settlement for expiry feature is enabled. Applicable to FUTURES cross.
-  instIdCode: number; // Instrument ID code. For simple binary encoding, must use instIdCode instead of instId.
-  /**
-   * Asset category of the instrument's base asset (see public `Instrument.instCategory` for values).
-   * 1: Crypto, 3: Stocks, 4: Commodities, 5: Forex, 6: Bonds, "": not available
-   */
-  instCategory?: string;
-  posLmtAmt: string; // Maximum position value (USD) for this instrument at the user level. Applicable to SWAP/FUTURES.
-  posLmtPct: string; // Maximum position ratio (e.g., 30 for 30%) a user may hold relative to platform's current total position value. Applicable to SWAP/FUTURES.
-  maxPlatOILmt: string; // Platform-wide maximum position value (USD) for this instrument. Applicable to SWAP/FUTURES.
-  /** Remaining long position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
-  longPosRemainingQuota?: string;
-  /** Remaining short position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
-  shortPosRemainingQuota?: string;
-  groupId?: string; // Instrument trading fee group ID
-  /** ELP maker permission. "0" = not enabled, "1" = enabled but no permission, "2" = enabled with permission */
-  elp?: string;
-  upcChg?: InstrumentUpcomingParamChange[];
-}
-⋮----
-/**
-   * FUTURES label (deprecated � prefer `expTime`; may include this_five_years, next_five_years, �).
-   */
-⋮----
-/** Deprecated; see `instCategory` on public `Instrument` where used. */
-⋮----
-contTdSwTime: string; // Continuous trading switch time. The switch time from call auction/prequote to continuous trading. Unix timestamp format in milliseconds.
-preMktSwTime: string; // The time premarket swap switched to normal swap. Unix timestamp format in milliseconds. Only applicable to premarket SWAP.
-⋮----
-openType: string; // Open type: fix_price (fix price opening), pre_quote (pre-quote), call_auction (call auction). Only applicable to SPOT/MARGIN.
-⋮----
-tradeQuoteCcyList: string[]; // List of quote currencies available for trading, e.g. ["USD", "USDC"]
-⋮----
-/** Instrument status: live, suspend, rebase (SWAP only), post_only (SWAP only), preopen, test */
-⋮----
-/** Trading rule types: normal, pre_market, rebase_contract */
-⋮----
-futureSettlement: boolean; // Whether daily settlement for expiry feature is enabled. Applicable to FUTURES cross.
-instIdCode: number; // Instrument ID code. For simple binary encoding, must use instIdCode instead of instId.
-/**
-   * Asset category of the instrument's base asset (see public `Instrument.instCategory` for values).
-   * 1: Crypto, 3: Stocks, 4: Commodities, 5: Forex, 6: Bonds, "": not available
-   */
-⋮----
-posLmtAmt: string; // Maximum position value (USD) for this instrument at the user level. Applicable to SWAP/FUTURES.
-posLmtPct: string; // Maximum position ratio (e.g., 30 for 30%) a user may hold relative to platform's current total position value. Applicable to SWAP/FUTURES.
-maxPlatOILmt: string; // Platform-wide maximum position value (USD) for this instrument. Applicable to SWAP/FUTURES.
-/** Remaining long position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
-⋮----
-/** Remaining short position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
-⋮----
-groupId?: string; // Instrument trading fee group ID
-/** ELP maker permission. "0" = not enabled, "1" = enabled but no permission, "2" = enabled with permission */
-⋮----
-export interface QuickMarginBorrowRepayResult {
-  instId: string;
-  ccy: string;
-  side: 'borrow' | 'repay';
-  amt: string;
-  posSide: string;
-  ts: string;
-}
-⋮----
-export interface QuickMarginBorrowRepayRecord {
-  instId: string;
-  ccy: string;
-  side: 'borrow' | 'repay';
-  accBorrowed: string;
-  amt: string;
-  refId: string;
-  ts: string;
-}
-⋮----
-export interface VIPInterest {
-  ordId: string;
-  ccy: string;
-  interest: string;
-  interestRate: string;
-  liab: string;
-  ts: string;
-}
-⋮----
-export interface VIPLoanOrder {
-  ts: string;
-  nextRefreshTime: string;
-  ccy: string;
-  ordId: string;
-  state: '1' | '2' | '3' | '4' | '5';
-  origRate: string;
-  curRate: string;
-  dueAmt: string;
-  borrowAmt: string;
-  repayAmt: string;
-}
-⋮----
-export interface VIPLoanOrderDetail {
-  amt: string;
-  ccy: string;
-  failReason: string;
-  rate: string;
-  ts: string;
-  type: '1' | '2' | '3' | '4';
-}
-⋮----
-export interface FixedLoanBorrowingLimitDetail {
-  ccy: string;
-  used: string;
-  borrowed: string;
-  availBorrow: string;
-  minBorrow: string;
-  term: string;
-}
-⋮----
-export interface FixedLoanBorrowingLimit {
-  totalBorrowLmt: string;
-  totalAvailBorrow: string;
-  borrowed: string;
-  used: string;
-  availRepay: string;
-  details: FixedLoanBorrowingLimitDetail[];
-  ts: string;
-}
-⋮----
-export interface FixedLoanBorrowQuote {
-  ccy: string;
-  term: string;
-  estAvailBorrow: string;
-  estRate: string;
-  estInterest: string;
-  penaltyInterest: string;
-  ts: string;
-}
-⋮----
-export interface SetMMPConfigResult {
-  instFamily: string;
-  timeInterval: string;
-  frozenInterval: string;
-  qtyLimit: string;
-}
-⋮----
-export interface MMPConfig {
-  frozenInterval: string;
-  instFamily: string;
-  mmpFrozen: boolean;
-  mmpFrozenUntil: string;
-  qtyLimit: string;
-  timeInterval: string;
-}
-⋮----
-export interface BorrowRepayHistoryItem {
-  ccy: string;
-  type: 'auto_borrow' | 'auto_repay' | 'manual_borrow' | 'manual_repay';
-  amt: string;
-  accBorrowed: string;
-  ts: string;
-}
-⋮----
-export interface SetCollateralAssetsResult {
-  type: 'all' | 'custom';
-  ccyList: string[];
-  collateralEnabled: boolean;
-}
-⋮----
-export interface GetCollateralAssetsResult {
-  ccy: string;
-  collateralEnabled: boolean;
-}
-⋮----
-export interface SetSettleCurrencyResult {
-  settleCcy: string;
-}
-⋮----
-export interface SetFeeTypeResult {
-  feeType: string;
-}
-⋮----
-export interface SetTradingConfigResult {
-  type: string; // Trading config type
-  stgyType: string; // Strategy type
-}
-⋮----
-type: string; // Trading config type
-stgyType: string; // Strategy type
-⋮----
-export interface UnmatchedInfo {
-  type: string; // Unmatched information type: spot_mode, futures_mode, isolated_margin, isolated_contract, positions_options, isolated_pending_orders, pending_orders_options, trading_bot, repay_borrowings, loan, delta_risk, collateral_all, risk_unit_type
-  deltaLever?: string; // Delta leverage. Applicable when type is delta_risk
-  ordList?: string[]; // Unmatched order list, order ID. Applicable when type is isolated_pending_orders/pending_orders_options
-  posList?: string[]; // Unmatched position list, position ID. Applicable when type is isolated_margin/isolated_contract/positions_options
-}
-⋮----
-type: string; // Unmatched information type: spot_mode, futures_mode, isolated_margin, isolated_contract, positions_options, isolated_pending_orders, pending_orders_options, trading_bot, repay_borrowings, loan, delta_risk, collateral_all, risk_unit_type
-deltaLever?: string; // Delta leverage. Applicable when type is delta_risk
-ordList?: string[]; // Unmatched order list, order ID. Applicable when type is isolated_pending_orders/pending_orders_options
-posList?: string[]; // Unmatched position list, position ID. Applicable when type is isolated_margin/isolated_contract/positions_options
-⋮----
-export interface PrecheckSetDeltaNeutralResult {
-  unmatchedInfoCheck: UnmatchedInfo[];
-}
-
-================
 File: src/types/rest/response/public-data.ts
 ================
 import { InstrumentType, numberInString } from '../shared.js';
@@ -7581,6 +7003,35 @@ export interface PublicFundingRate {
   ts: string;
 }
 ⋮----
+/**
+ * @see GET /api/v5/public/insurance-fund (Get security fund)
+ */
+export interface InsuranceFundDetail {
+  ccy?: string;
+  bal?: string;
+  amt?: string;
+  type?: string;
+  maxBal?: string;
+  maxBalTs?: string;
+  decRate?: string;
+  adlType?: string;
+  adlBal?: string;
+  adlRecBal?: string;
+  /** @deprecated Returns "" per 2026-06-09 changelog */
+  adlRate?: string;
+  /** @deprecated Returns "" per 2026-06-09 changelog */
+  adlRecRate?: string;
+}
+⋮----
+/** @deprecated Returns "" per 2026-06-09 changelog */
+⋮----
+/** @deprecated Returns "" per 2026-06-09 changelog */
+⋮----
+export interface InsuranceFund {
+  instType?: string;
+  details: InsuranceFundDetail[];
+}
+⋮----
 export interface FundingRateHistory {
   /** Perpetual (`SWAP`) or X-Perp (`FUTURES`). */
   instType: string;
@@ -7814,615 +7265,6 @@ export interface EventContractMarket {
   settleValue: string;
   disputed: boolean;
 }
-
-================
-File: README.md
-================
-# Node.js & Typescript OKX (OKEX) API & WebSocket SDK
-
-[![E2E Tests](https://github.com/tiagosiebler/okx-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/okx-api/actions/workflows/e2etest.yml)
-[![npm downloads](https://img.shields.io/npm/dt/okx-api)][1]
-[![npm version](https://img.shields.io/npm/v/okx-api)][1]
-[![npm size](https://img.shields.io/bundlephobia/min/okx-api/latest)][1]
-[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/okx-api)][1]
-[![CodeFactor](https://www.codefactor.io/repository/github/tiagosiebler/okx-api/badge)](https://www.codefactor.io/repository/github/tiagosiebler/okx-api)
-
-<p align="center">
-  <a href="https://www.npmjs.com/package/okx-api">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/okx-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/okx-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
-    </picture>
-  </a>
-</p>
-
-[1]: https://www.npmjs.com/package/okx-api
-
-> [!TIP]
-> Upcoming change: As part of the [Siebly.io](https://siebly.io/?ref=ghokx) brand, this SDK will soon be hosted under the [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
-
-Complete, updated & performant Node.js SDK for the OKX(OKEX) APIs and WebSockets:
-
-- Complete integration with OKX REST APIs, WebSockets & WebSocket APIs.
-- TypeScript support (with type declarations for most API requests & responses).
-- Over 100 end-to-end tests making real API calls & WebSocket connections, validating any changes before they reach npm.
-- Supports all available OKX regions:
-  - OKX Global (www.okx.com), by default.
-  - OKX EEA (my.okx.com), by setting `market: 'EEA'`.
-  - OKX US (app.okx.com), by setting `market: 'US'`.
-- Actively maintained with a modern, promise-driven interface.
-- Robust WebSocket integration
-  - Configurable connection heartbeats (automatically detect failing connections).
-  - Automatic reconnect then resubscribe workflows.
-  - Automatic authentication and heartbeat handling.
-- Supports WebSocket API in all supported regions & product groups:
-  - Use the WebsocketClient's event-driven `sendWSAPIRequest()` method, or;
-  - Use the WebsocketAPIClient for a REST-like experience.
-    - Use the WebSocket API like a REST API!
-    - Automatic routing to business vs private WebSocket endpoints.
-    - End to end types.
-    - See [examples/ws-api-client.ts](./examples/ws-api-client.ts) for a demonstration.
-- Browser support (via webpack bundle - see "Browser Usage" below).
-- QuickStart Guide: https://siebly.io/sdk/okx/javascript
-
-## Table of Contents
-
-- [Installation](#installation)
-- [Issues & Discussion](#issues--discussion)
-- [Related Projects](#related-projects)
-- [Documentation](#documentation)
-- [Contributions & Thanks](#contributions--thanks)
-- [Structure](#structure)
-- [Usage](#usage)
-  - [REST Client](#rest-client)
-    - [Requests & Responses](#requests--responses)
-    - [Example](#example)
-  - [WebSockets](#websockets)
-    - [Sending Orders via WebSockets](#sending-orders-via-websockets)
-    - [Receiving Realtime Data](#receiving-realtime-data)
-    - [Public Events](#public-events)
-    - [Private Events](#private-events)
-- [Browser/Frontend Usage](#browserfrontend-usage)
-  - [Import](#import)
-  - [Webpack](#webpack)
-- [Use with LLMs & AI](#use-with-llms--ai)
-- [Contributions & Pull Requests](#contributions--pull-requests)
-- [Used By](#used-by)
-- [Star History](#star-history)
-
-## Installation
-
-```bash
-npm install okx-api
-```
-
-## Issues & Discussion
-
-- Issues? Check the [issues tab](https://github.com/tiagosiebler/okx-api/issues).
-- Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
-- Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
-
-<!-- template_related_projects -->
-
-## Related Projects
-
-Check out our JavaScript/TypeScript/Node.js SDKs & Projects:
-
-- Visit our website: [https://Siebly.io](https://siebly.io/?ref=gh)
-- Try our REST API & WebSocket SDKs published on npmjs:
-  - [Bybit Node.js SDK: bybit-api](https://www.npmjs.com/package/bybit-api)
-  - [Kraken Node.js SDK: @siebly/kraken-api](https://www.npmjs.com/package/@siebly/kraken-api)
-  - [OKX Node.js SDK: okx-api](https://www.npmjs.com/package/okx-api)
-  - [Binance Node.js SDK: binance](https://www.npmjs.com/package/binance)
-  - [Gate (gate.com) Node.js SDK: gateio-api](https://www.npmjs.com/package/gateio-api)
-  - [Bitget Node.js SDK: bitget-api](https://www.npmjs.com/package/bitget-api)
-  - [Kucoin Node.js SDK: kucoin-api](https://www.npmjs.com/package/kucoin-api)
-  - [Coinbase Node.js SDK: coinbase-api](https://www.npmjs.com/package/coinbase-api)
-  - [Bitmart Node.js SDK: bitmart-api](https://www.npmjs.com/package/bitmart-api)
-- Try my misc utilities:
-  - [OrderBooks Node.js: orderbooks](https://www.npmjs.com/package/orderbooks)
-  - [Crypto Exchange Account State Cache: accountstate](https://www.npmjs.com/package/accountstate)
-- Check out my examples:
-  - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
-  <!-- template_related_projects_end -->
-
-## Documentation
-
-Most methods accept JS objects. These can be populated using parameters specified by okx's API documentation, or check the type definition in the rest-client class methods.
-
-- [RestClient](src/rest-client.ts)
-- [OKX API Documentation](https://www.okx.com/docs-v5/en/#rest-api)
-- [REST Endpoint Function List](./docs/endpointFunctionList.md)
-
-## Contributions & Thanks
-
-Support my efforts to make algo trading accessible to all - register with my referral links:
-
-- [Bybit](https://www.bybit.com/en-US/register?affiliate_id=9410&language=en-US&group_id=0&group_type=1)
-- [Binance](https://www.binance.com/en/register?ref=20983262)
-- [OKX](https://www.okx.com/join/18504944)
-
-For more ways to give thanks & support my efforts, visit [Contributions & Thanks](https://github.com/tiagosiebler/awesome-crypto-examples/wiki/Contributions-&-Thanks)!
-
-## Structure
-
-This project uses typescript. Resources are stored in 3 key structures:
-
-- [src](./src) - the whole connector written in typescript
-- [lib](./lib) - the javascript version of the project (compiled from typescript). This should not be edited directly, as it will be overwritten with each release. This is also the version published to npm.
-- [dist](./dist) - the packed bundle of the project for use in browser environments (manual, using webpack).
-- [examples](./examples) - some implementation examples & demonstrations. Contributions are welcome!
-
----
-
-## Usage
-
-Create API credentials at okx
-
-- [OKX/account/API](https://www.okx.com/account/my-api)
-
-## REST Client
-
-### Requests & Responses
-
-- If your IDE doesn't have IntelliSense, check the [rest-client.ts](./src/rest-client.ts) for a list of methods, params & return types.
-- Requests follow the same ordering and format as the categories in the [API docs](https://www.okx.com/docs-v5/en/#rest-api).
-- Responses are parsed automatically for less nesting. Error responses are thrown in full:
-  - If the response looks successful (HTTP 200 and "code" in the response body === "0"), only the `data` property is directly (without the `code`, `data` & `msg` properties).
-  - If the response looks like an error (HTTP error OR the "code" property in the response does not equal "0"), the full response is thrown (including `code` and `msg` properties). See the interface for [APIResponse<T>](./src/types/rest/shared.ts).
-
-### Example
-
-```ts
-import { RestClient } from 'okx-api';
-
-const client = new RestClient({
-  apiKey: 'apiKeyHere',
-  apiSecret: 'apiSecretHere',
-  apiPass: 'apiPassHere',
-  // For Global users (www.okx.com), you don't need to set the market.
-  // It will use global by default.
-  // Not needed: market: 'GLOBAL',
-
-  // For EEA users (my.okx.com), set market to "EEA":
-  // market: 'EEA',
-
-  // For US users (app.okx.com), set market to "US":
-  // market: 'US',
-});
-
-// Submit a buy and sell market order
-(async () => {
-  try {
-    const allBalances = await client.getBalance();
-    console.log('All balances: ', allBalances);
-
-    const buyResult = await client.submitOrder({
-      instId: 'BTC-USDT',
-      ordType: 'market',
-      side: 'buy',
-      sz: '0.1',
-      tdMode: 'cash',
-      tgtCcy: 'base_ccy',
-    });
-    console.log('buy order result: ', buyResult);
-
-    const sellResult = await client.submitOrder({
-      instId: 'BTC-USDT',
-      ordType: 'market',
-      side: 'sell',
-      sz: '0.1',
-      tdMode: 'cash',
-      tgtCcy: 'base_ccy',
-    });
-    console.log('Sell order result: ', sellResult);
-  } catch (e) {
-    console.error('request failed: ', e);
-  }
-})();
-```
-
-## WebSockets
-
-This connector includes a high-performance Node.js, TypeScript & JavaScript WebSocket client for the OKX public & private WebSocket, including the OKX WebSocket API for order placement. API credentials are optional unless private streams will be used (such as account order updates).
-
-- If your IDE doesn't have IntelliSense, check the [websocket-client.ts](./src/websocket-client.ts) for a list of methods, params & return types.
-- When subscribing to channels, only the "args" should be passed as an object or array when calling the websocket client subcribe() function: [API docs](https://www.okx.com/docs-v5/en/#websocket-api-subscribe).
-- TypeScript recommended (but it is not required) for a richer experience:
-  ![typescript-subscribe](./docs/images/subscribe-with-typescript.gif)
-- The ws client will automatically open connections as needed when subscribing to a channel.
-- If the connection is lost for any reason, the ws client will detect this (via the connection heartbeats). It will then:
-  - Automatically teardown the dead connection.
-  - Automatically respawn a fresh connection.
-  - Automatically reauthenticate, if using private channels.
-  - Automatically resubscribe to previously subscribed topics.
-  - Resume producing events as before, without extra handling needed in your logic.
-- The ws client will automatically authenticate if accounts are provided and a private channel is subscribed to.
-- Up to 100 accounts are supported on the private connection, as per the [API docs](https://www.okx.com/docs-v5/en/#websocket-api-login). Authentication is automatic if accounts are provided.
-- For examples in using the websocket client, check the examples in the repo:
-  - Private channels (account data): [examples/ws-private.ts](./examples/ws-private.ts)
-  - Public chanels (market data): [examples/ws-public.ts](./examples/ws-public.ts)
-  - These examples are written in TypeScript, so can be executed with ts-node for easy testing:
-    `ts-node examples/ws-private.ts`
-  - Or convert them to javascript:
-    - Change the `import { ... } from 'okx-api'` to `const { ... } = require('okx-api');`
-    - Rename the file to `ws-private.js`
-    - And execute with node: `node examples/ws-private.js`
-
-### Sending orders via WebSockets
-
-OKX supports some order management capabilities via a persisted WebSocket connection. This SDK supports this with two convenient approaches.
-
-The recommended route is to use the dedicated WebsocketAPIClient class, included with this SDK:
-
-- Dedicated functions for every available WebSocket API operation
-- Fully typed requests and responses
-- Asynchronous promisified wrapper around WS API commands.
-
-It looks & feels like a REST API client, but uses WebSockets, via the WebsocketClient's sendWSAPIRequest method (which you can use directly if you prefer).
-
-A simple example is below but for a more thorough example, check the example here: [./examples/ws-api-client.ts](./examples/ws-api-client.ts).
-
-```typescript
-import { WebsocketAPIClient } from 'okx-api';
-// or if you prefer require:
-// const { WebsocketAPIClient } = require("okx-api");
-
-// For private events, all 3 of the following are required (per account):
-const API_KEY = process.env.API_KEY_COM;
-const API_SECRET = process.env.API_SECRET_COM;
-const API_PASSPHRASE = process.env.API_PASSPHRASE_COM;
-
-// If running from CLI in unix, you can pass env vars as such:
-// API_KEY_COM='lkm12n3-2ba3-1mxf-fn13-lkm12n3a' API_SECRET_COM='035B2B9637E1BDFFEE2646BFBDDB8CE4' API_PASSPHRASE_COM='ComplexPa$$!23$5^' ts-node examples/ws-private.ts
-
-const wsClient = new WebsocketAPIClient({
-  // For Global users (www.okx.com), you don't need to set the market.
-  // It will use global by default.
-  // Not needed: market: 'GLOBAL',
-
-  // For EEA users (my.okx.com), set market to "EEA":
-  // market: 'EEA',
-
-  // For US users (app.okx.com), set market to "US":
-  // market: 'US',
-
-  accounts: [
-    {
-      apiKey: API_KEY,
-      apiSecret: API_SECRET,
-      apiPass: API_PASSPHRASE,
-    },
-  ],
-});
-
-async function start() {
-  // Optional: prepare the WebSocket API connection in advance.
-  // This happens automatically but you can do this early before making any API calls, to prevent delays from a cold start.
-  // await wsClient.connectWSAPI();
-
-  /**
-   * OKX's WebSocket API be used like a REST API, through this SDK's WebsocketAPIClient. The WebsocketAPIClient is a utility class wrapped around WebsocketClient's sendWSAPIRequest() capabilities.
-   *
-   * Each request sent via the WebsocketAPIClient will automatically:
-   * - route via the active WS API connection
-   * - return a Promise, which automatically resolves/rejects when a matching response is received
-   */
-
-  /**
-   * Place Order
-   * https://www.okx.com/docs-v5/en/#order-book-trading-trade-ws-place-order
-   */
-  try {
-    const res = await wsClient.submitNewOrder({
-      instId: 'BTC-USDT',
-      tdMode: 'cash',
-      side: 'buy',
-      ordType: 'market',
-      sz: '100',
-    });
-    /**
-      const res = {
-        id: '2',
-        op: 'order',
-        code: '1',
-        msg: '',
-        data: [
-          {
-            tag: '159881cb7207BCDE',
-            ts: '1753714603721',
-            ordId: '',
-            clOrdId: '',
-            sCode: '51008',
-            sMsg: 'Order failed. Insufficient USDT balance in account.'
-          }
-        ],
-        inTime: '1753714603720755',
-        outTime: '1753714603721942',
-        wsKey: 'prodPrivate',
-        isWSAPIResponse: false
-      }
-
-      const res =  {
-        id: '2',
-        op: 'order',
-        code: '1',
-        msg: '',
-        data: [
-          {
-            tag: '159881cb7207BCDE',
-            ts: '1753714567149',
-            ordId: '',
-            clOrdId: '',
-            sCode: '51010',
-            sMsg: "You can't complete this request under your current account mode."
-          }
-        ],
-        inTime: '1753714567149196',
-        outTime: '1753714567149913',
-        wsKey: 'prodPrivate',
-        isWSAPIResponse: false
-      }
-     */
-
-    console.log(new Date(), 'WS API "submitNewOrder()" result: ', res);
-  } catch (e) {
-    console.error(new Date(), 'Exception with WS API "submitNewOrder()": ', e);
-  }
-
-  /**
-   * Submit multiple orders in a batch
-   * https://www.okx.com/docs-v5/en/#order-book-trading-trade-ws-place-multiple-orders
-   */
-  try {
-    const res = await wsClient.submitMultipleOrders([
-      {
-        instId: 'BTC-USDT',
-        tdMode: 'cash',
-        side: 'buy',
-        ordType: 'market',
-        sz: '100',
-      },
-      {
-        instId: 'BTC-USDT',
-        tdMode: 'cash',
-        side: 'buy',
-        ordType: 'market',
-        sz: '50',
-      },
-    ]);
-    console.log(new Date(), 'WS API "submitMultipleOrders()" result: ', res);
-  } catch (e) {
-    console.error(
-      new Date(),
-      'Exception with WS API "submitMultipleOrders()": ',
-      e,
-    );
-  }
-}
-
-start();
-```
-
-### Receiving realtime data
-
-The below example demonstrates connecting as a consumer, to receive WebSocket events from OKX, using the included WebsocketClient:
-
-```javascript
-import { WebsocketClient } from 'okx-api';
-// or if you prefer require:
-// const { WebsocketClient } = require("okx-api");
-
-// For private events, all 3 of the following are required (per account):
-const API_KEY = process.env.API_KEY_COM;
-const API_SECRET = process.env.API_SECRET_COM;
-const API_PASSPHRASE = process.env.API_PASSPHRASE_COM;
-
-// If running from CLI in unix, you can pass env vars as such:
-// API_KEY_COM='lkm12n3-2ba3-1mxf-fn13-lkm12n3a' API_SECRET_COM='035B2B9637E1BDFFEE2646BFBDDB8CE4' API_PASSPHRASE_COM='ComplexPa$$!23$5^' ts-node examples/ws-private.ts
-
-// Note the single quotes, preventing special characters such as $ from being incorrectly passed
-
-const wsClient = new WebsocketClient({
-  // For Global users (www.okx.com), you don't need to set the market.
-  // It will use global by default.
-  // Not needed: market: 'GLOBAL',
-
-  // For EEA users (my.okx.com), set market to "EEA":
-  // market: 'EEA',
-
-  // For US users (app.okx.com), set market to "US":
-  // market: 'US',
-
-  accounts: [
-    // For private topics, include one or more accounts in an array. Otherwise only public topics will work
-    {
-      apiKey: API_KEY,
-      apiSecret: API_SECRET,
-      apiPass: API_PASSPHRASE,
-    },
-    // {
-    //   apiKey: 'yourApiKeyHere',
-    //   apiSecret: 'yourApiSecretHere',
-    //   apiPass: 'yourApiPassHere',
-    // },
-    // {
-    //   apiKey: 'anotherAccountKey',
-    //   apiSecret: 'anotherAccountSecret',
-    //   apiPass: 'anotherAccountPass',
-    // },
-  ],
-});
-
-// Raw data will arrive on the 'update' event
-wsClient.on('update', (data) => {
-  console.log('ws update (raw data received)', JSON.stringify(data));
-});
-
-wsClient.on('open', (data) => {
-  console.log('connection opened open:', data.wsKey);
-});
-
-// Replies (e.g. authenticating or subscribing to channels) will arrive on the 'response' event
-wsClient.on('response', (data) => {
-  // console.log('ws response: ', JSON.stringify(data, null, 2));
-  console.log('ws response: ', JSON.stringify(data));
-});
-
-wsClient.on('reconnect', ({ wsKey }) => {
-  console.log('ws automatically reconnecting.... ', wsKey);
-});
-wsClient.on('reconnected', (data) => {
-  console.log('ws has reconnected ', data?.wsKey);
-});
-wsClient.on('exception', (data) => {
-  console.error('ws exception: ', data);
-});
-
-/**
- * Simply call subscribe to request the channels that you're interested in.
- *
- * If authentication is required, the WSClient will automatically authenticate with the available credentials.
- */
-
-// Subscribe one event at a time:
-wsClient.subscribe({
-  channel: 'account',
-});
-
-// OR, combine multiple subscription events into one request using an array instead of an object:
-wsClient.subscribe([
-  {
-    channel: 'account',
-  },
-  {
-    channel: 'positions',
-    instType: 'ANY',
-  },
-]);
-
-// Public topics, for comparison. These do not require authentication / api keys:
-wsClient.subscribe([
-  {
-    channel: 'instruments',
-    instType: 'SPOT',
-  },
-  {
-    channel: 'instruments',
-    instType: 'FUTURES',
-  },
-  {
-    channel: 'tickers',
-    instId: 'LTC-BTC',
-  },
-]);
-```
-
-#### Public Events
-
-See [examples/ws-public.ts](./examples/ws-public.ts) for a full example:
-
-![typescript-events-public](./docs/images/subscribe-events-public.gif)
-
-#### Private Events
-
-See [examples/ws-private.ts](./examples/ws-private.ts) for a full example:
-
-![typescript-events](./docs/images/subscribe-events.gif)
-
-## Browser/Frontend Usage
-
-### Import
-
-This is the "modern" way, allowing the package to be directly imported into frontend projects with full typescript support.
-
-1. Install these dependencies
-   ```sh
-   npm install crypto-browserify stream-browserify
-   ```
-2. Add this to your `tsconfig.json`
-   ```json
-   {
-     "compilerOptions": {
-       "paths": {
-         "crypto": [
-           "./node_modules/crypto-browserify"
-         ],
-         "stream": [
-           "./node_modules/stream-browserify"
-         ]
-   }
-   ```
-3. Declare this in the global context of your application (ex: in polyfills for angular)
-   ```js
-   (window as any).global = window;
-   ```
-
-### Webpack
-
-This is the "old" way of using this package on webpages. This will build a minified js bundle that can be pulled in using a script tag on a website.
-
-Build a bundle using webpack:
-
-- `npm install`
-- `npm build`
-- `npm pack`
-
-The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
-
-## Use with LLMs & AI
-
-This SDK includes a bundled `llms.txt` file in the root of the repository. If you're developing with LLMs, use the included `llms.txt` with your LLM - it will significantly improve the LLMs understanding of how to correctly use this SDK.
-
-This file contains AI optimised structure of all the functions in this package, and their parameters for easier use with any learning models or artificial intelligence.
-
----
-
-<!-- template_contributions -->
-
-### Contributions & Thanks
-
-Have my projects helped you? Share the love, there are many ways you can show your thanks:
-
-- Star & share my projects.
-- Are my projects useful? Sponsor me on Github and support my effort to maintain & improve them: https://github.com/sponsors/tiagosiebler
-- Have an interesting project? Get in touch & invite me to it.
-- Or buy me all the coffee:
-  - ETH(ERC20): `0xA3Bda8BecaB4DCdA539Dc16F9C54a592553Be06C` <!-- metamask -->
-- Sign up with my referral links:
-  - OKX (receive a 20% fee discount!): https://www.okx.com/join/42013004
-  - Binance (receive a 20% fee discount!): https://accounts.binance.com/register?ref=OKFFGIJJ
-  - HyperLiquid (receive a 4% fee discount!): https://app.hyperliquid.xyz/join/SDK
-  - Gate: https://www.gate.io/signup/NODESDKS?ref_type=103
-
-<!---
-old ones:
-  - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
-  - BTC(SegWit): `bc1ql64wr9z3khp2gy7dqlmqw7cp6h0lcusz0zjtls`
-  - ETH(ERC20): `0xe0bbbc805e0e83341fadc210d6202f4022e50992`
-  - USDT(TRC20): `TA18VUywcNEM9ahh3TTWF3sFpt9rkLnnQa
-  - gate: https://www.gate.io/signup/AVNNU1WK?ref_type=103
-
--->
-<!-- template_contributions_end -->
-
-## Contributions & Pull Requests
-
-Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.
-
-## Used By
-
-The following represents some of the known public projects that use this SDK on GitHub:
-
-[![Repository Users Preview Image](https://dependents.info/tiagosiebler/okx-api/image)](https://github.com/tiagosiebler/okx-api/network/dependents)
-
-<!-- template_star_history -->
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
-
-<!-- template_star_history_end -->
 
 ================
 File: src/types/rest/request/trade.ts
@@ -8788,6 +7630,710 @@ export interface OrderPrecheckRequest {
 /** EVENTS: `yes` / `no`. */
 
 ================
+File: src/types/rest/response/private-account.ts
+================
+import {
+  AccountLevel,
+  MarginMode,
+  PositionSide,
+  WithdrawState,
+} from '../shared.js';
+import type { InstrumentUpcomingParamChange } from './public-data.js';
+⋮----
+export interface AccountBalanceDetail {
+  availBal: string;
+  availEq: string;
+  cashBal: string;
+  ccy: string;
+  crossLiab: string;
+  disEq: string;
+  eq: string;
+  eqUsd: string;
+  frozenBal: string;
+  interest: string;
+  isoEq: string;
+  isoLiab: string;
+  isoUpl: string;
+  liab: string;
+  maxLoan: string;
+  mgnRatio: string;
+  notionalLever: string;
+  ordFrozen: string;
+  twap: string;
+  uTime: string;
+  upl: string;
+  uplLiab: string;
+  stgyEq: string;
+  spotBal: string; // Spot balance. The unit is currency, e.g. BTC.
+  openAvgPx: string[]; // Spot average cost price. The unit is USD.
+  accAvgPx: string[]; // Spot accumulated cost price. The unit is USD.
+  spotUpl: string; // Spot unrealized profit and loss. The unit is USD.
+  spotUplRatio: string; // Spot unrealized profit and loss ratio.
+  totalPnl: string; // Spot accumulated profit and loss. The unit is USD.
+  totalPnlRatio: string; // Spot accumulated profit and loss ratio.
+}
+⋮----
+spotBal: string; // Spot balance. The unit is currency, e.g. BTC.
+openAvgPx: string[]; // Spot average cost price. The unit is USD.
+accAvgPx: string[]; // Spot accumulated cost price. The unit is USD.
+spotUpl: string; // Spot unrealized profit and loss. The unit is USD.
+spotUplRatio: string; // Spot unrealized profit and loss ratio.
+totalPnl: string; // Spot accumulated profit and loss. The unit is USD.
+totalPnlRatio: string; // Spot accumulated profit and loss ratio.
+⋮----
+export interface AccountBalance {
+  adjEq: string;
+  details: AccountBalanceDetail[];
+  imr: string;
+  isoEq: string;
+  mgnRatio: string;
+  mmr: string;
+  notionalUsd: string;
+  notionalUsdForBorrow: string;
+  notionalUsdForFutures: string;
+  notionalUsdForOption: string;
+  notionalUsdForSwap: string;
+  ordFroz: string;
+  totalEq: string;
+  uTime: string;
+  spotCopyTradingEq: string;
+  upl: string;
+  frpType?: string;
+  // Delta neutral strategy fields
+  delta: string; // Delta (USD)
+  deltaLever: string; // Delta neutral strategy account level delta leverage (deltaLever = delta / totalEq)
+  deltaNeutralStatus: string; // Delta risk status: 0=normal, 1=transfer restricted, 2=delta reducing
+}
+⋮----
+// Delta neutral strategy fields
+delta: string; // Delta (USD)
+deltaLever: string; // Delta neutral strategy account level delta leverage (deltaLever = delta / totalEq)
+deltaNeutralStatus: string; // Delta risk status: 0=normal, 1=transfer restricted, 2=delta reducing
+⋮----
+export interface AccountPosition {
+  adl: string;
+  availPos: string;
+  avgPx: string;
+  cTime: string;
+  ccy: string;
+  deltaBS: string;
+  deltaPA: string;
+  gammaBS: string;
+  gammaPA: string;
+  imr: string;
+  instId: string;
+  instType: string;
+  interest: string;
+  usdPx: string;
+  last: string;
+  lever: string;
+  liab: string;
+  liabCcy: string;
+  liqPx: string;
+  markPx: string;
+  margin: string;
+  mgnMode: MarginMode;
+  mgnRatio: string;
+  mmr: string;
+  notionalUsd: string;
+  optVal: string;
+  pTime: string;
+  pos: string;
+  hedgedPos: string; // Hedged position size. Only returned for accounts in delta neutral strategy (stgyType:1). Returns "" for accounts in general strategy.
+  posCcy: string;
+  posId: string;
+  posSide: PositionSide;
+  thetaBS: string;
+  thetaPA: string;
+  tradeId: string;
+  uTime: string;
+  upl: string;
+  uplRatio: string;
+  vegaBS: string;
+  vegaPA: string;
+}
+⋮----
+hedgedPos: string; // Hedged position size. Only returned for accounts in delta neutral strategy (stgyType:1). Returns "" for accounts in general strategy.
+⋮----
+export interface HistoricAccountPosition {
+  cTime: string;
+  ccy: string;
+  closeAvgPx: string;
+  closeTotalPos: string;
+  instId: string;
+  instType: string;
+  lever: string;
+  mgnMode: MarginMode;
+  openAvgPx: string;
+  openMaxPos: string;
+  pnl: string;
+  pnlRatio: string;
+  posId: string;
+  posSide: PositionSide;
+  triggerPx: string;
+  type: string;
+  uTime: string;
+  uly: string;
+}
+⋮----
+export interface AccountBalanceRiskData {
+  ccy: string;
+  disEq: string;
+  eq: string;
+}
+⋮----
+export interface AccountPositionRiskData {
+  baseBal: string;
+  ccy: string;
+  instId: string;
+  instType: string;
+  mgnMode: MarginMode;
+  notionalCcy: string;
+  notionalUsd: string;
+  pos: string;
+  posCcy: string;
+  posId: string;
+  posSide: PositionSide;
+  quoteBal: string;
+}
+⋮----
+export interface AccountPositionRisk {
+  adjEq: string;
+  balData: AccountBalanceRiskData[];
+  posData: AccountPositionRiskData[];
+  ts: string;
+}
+⋮----
+export interface AccountBill {
+  bal: string;
+  balChg: string;
+  billId: string;
+  ccy: string;
+  execType: string;
+  fee: string;
+  from: string;
+  instId: string;
+  instType: string;
+  mgnMode: MarginMode;
+  notes: string;
+  ordId: string;
+  pnl: string;
+  posBal: string;
+  posBalChg: string;
+  subType: string;
+  sz: string;
+  to: string;
+  ts: string;
+  type: string;
+  earnAmt?: string;
+  earnApr?: string;
+}
+⋮----
+export interface BillSubTypeDetail {
+  subType: string;
+  subTypeDesc: string;
+}
+⋮----
+/**
+ * @see GET /api/v5/account/subtypes
+ */
+export interface AccountBillTypeDefinition {
+  type: string;
+  typeDesc: string;
+  subTypeDetails: BillSubTypeDetail[];
+}
+⋮----
+/**
+ * Apply (POST) may return { result, ts }; get link (GET) may return { fileHref, state, ts }.
+ */
+export interface AccountHistoryBill {
+  fileHref?: string;
+  result?: string;
+  state?: 'finished' | 'ongoing' | 'failed' | string;
+  ts: string;
+}
+⋮----
+export interface AccountConfiguration {
+  acctLv: string;
+  autoLoan: boolean;
+  ctIsoMode: string;
+  greeksType: string;
+  level: string;
+  levelTmp: string;
+  mgnIsoMode: string;
+  posMode: string;
+  spotOffsetType: string;
+  stgyType: string; // Strategy type: 0=general strategy, 1=delta neutral strategy
+  uid: string;
+  label: string;
+  roleType: string;
+  traderInsts: any[];
+  spotRoleType: string;
+  spotTraderInsts: any[];
+  opAuth: string;
+  kycLv: string;
+  ip: string;
+  perm: string;
+  mainUid: string;
+  discountType: '0' | '1';
+  enableSpotBorrow: boolean;
+  spotBorrowAutoRepay: boolean;
+  feeType: string;
+  settleCcy: string;
+  settleCcyList: string[];
+}
+⋮----
+stgyType: string; // Strategy type: 0=general strategy, 1=delta neutral strategy
+⋮----
+export interface AccountPositionModeResult {
+  posMode: string;
+}
+⋮----
+export interface AccountModeResult {
+  acctLv: AccountLevel;
+}
+⋮----
+export interface AutoLoanResult {
+  autoLoan: boolean;
+}
+⋮----
+export interface AccountLeverageResult {
+  lever: string;
+  mgnMode: MarginMode;
+  instId: string;
+  posSide: PositionSide;
+}
+⋮----
+export interface AccountMaxOrderAmount {
+  ccy: string;
+  instId: string;
+  maxBuy: string;
+  maxSell: string;
+}
+⋮----
+export interface AccountMaxTradableAmount {
+  instId: string;
+  availBuy: string;
+  availSell: string;
+}
+⋮----
+export interface AccountChangeMarginResult {
+  amt: string;
+  ccy: string;
+  instId: string;
+  leverage: string;
+  posSide: PositionSide;
+  type: string;
+}
+⋮----
+export interface AccountLeverage {
+  instId: string;
+  mgnMode: MarginMode;
+  posSide: PositionSide;
+  lever: string;
+}
+⋮----
+export interface AccountMaxLoan {
+  instId: string;
+  mgnMode: MarginMode;
+  mgnCcy: string;
+  maxLoan: string;
+  ccy: string;
+  side: string;
+}
+⋮----
+export interface FeeGroup {
+  taker: string;
+  maker: string;
+  groupId: string;
+  /** ELP Maker effective fee rate. Returns "" if ELP is not applicable to the instrument. @see 2026-05-20 changelog */
+  elpMaker?: string;
+}
+⋮----
+/** ELP Maker effective fee rate. Returns "" if ELP is not applicable to the instrument. @see 2026-05-20 changelog */
+⋮----
+export interface AccountFeeRate {
+  category: never;
+  delivery: string;
+  exercise: string;
+  instType: string;
+  level: string;
+  maker: string;
+  makerU: string;
+  taker: string;
+  takerU: string;
+  settle?: string;
+  ts: string;
+  ruleType: string;
+  feeGroup?: FeeGroup[]; // Fee groups. Applicable to SPOT/MARGIN/SWAP/FUTURES/OPTION
+}
+⋮----
+feeGroup?: FeeGroup[]; // Fee groups. Applicable to SPOT/MARGIN/SWAP/FUTURES/OPTION
+⋮----
+export interface AccountIsolatedMode {
+  isoMode: 'autonomy' | 'automatic';
+}
+⋮----
+export interface AdjustLeverageInfo {
+  estAvailQuoteTrans: string;
+  estAvailTrans: string;
+  estLiqPx: string;
+  estMgn: string;
+  estQuoteMgn: string;
+  estMaxAmt: string;
+  estQuoteMaxAmt: string;
+  existOrd: boolean;
+  maxLever: string;
+  minLever: string;
+}
+⋮----
+export interface InterestAccrued {
+  type: '1' | '2';
+  ccy: string;
+  instId: string;
+  mgnMode: MarginMode;
+  interest: string;
+  interestRate: string;
+  liab: string;
+  ts: string;
+}
+⋮----
+export interface InterestRate {
+  interestRate: string;
+  ccy: string;
+}
+⋮----
+export interface Greeks {
+  greeksType: string;
+}
+⋮----
+export interface MaxWithdrawal {
+  ccy: string;
+  maxWd: string;
+  maxWdEx: string;
+  spotOffsetMaxWd: string;
+  spotOffsetMaxWdEx: string;
+}
+⋮----
+export interface AccountRiskState {
+  atRisk: string;
+  atRiskIdx: string;
+  atRiskMgn: string;
+  ts: string;
+}
+⋮----
+export interface WithdrawalHistory {
+  ccy: string;
+  chain: string;
+  nonTradableAsset: boolean;
+  amt: string;
+  ts: string;
+  from: string;
+  areaCodeFrom: string;
+  to: string;
+  areaCodeTo: string;
+  tag: string;
+  pmtId: string;
+  memo: string;
+  addrExt: any;
+  txId: string;
+  fee: string;
+  feeCcy: string;
+  state: WithdrawState;
+  wdId: string;
+  clientId: string;
+}
+⋮----
+export interface AccountInstrument {
+  baseCcy: string;
+  ctMult: string;
+  ctType: string;
+  ctVal: string;
+  ctValCcy: string;
+  expTime: string;
+  instFamily: string;
+  instId: string;
+  instType: string;
+  seriesId?: string;
+  uly?: string;
+  /**
+   * FUTURES label (deprecated: prefer `expTime`; may include this_five_years, next_five_years, ...).
+   */
+  alias?: string;
+  /** Deprecated; see `instCategory` on public `Instrument` where used. */
+  category?: string;
+  lever: string;
+  listTime: string;
+  contTdSwTime: string; // Continuous trading switch time. The switch time from call auction/prequote to continuous trading. Unix timestamp format in milliseconds.
+  preMktSwTime: string; // The time premarket swap switched to normal swap. Unix timestamp format in milliseconds. Only applicable to premarket SWAP.
+  lotSz: string;
+  maxIcebergSz: string;
+  maxLmtAmt: string;
+  maxLmtSz: string;
+  maxMktAmt: string;
+  maxMktSz: string;
+  maxStopSz: string;
+  maxTriggerSz: string;
+  maxTwapSz: string;
+  minSz: string;
+  optType: string;
+  openType: string; // Open type: fix_price (fix price opening), pre_quote (pre-quote), call_auction (call auction). Only applicable to SPOT/MARGIN.
+  quoteCcy: string;
+  tradeQuoteCcyList: string[]; // List of quote currencies available for trading, e.g. ["USD", "USDC"]
+  settleCcy: string;
+  /** Instrument status: live, suspend, rebase (SWAP only), post_only (SWAP only), preopen, test */
+  state: string;
+  stk: string;
+  tickSz: string;
+  /** Trading rule types: normal, pre_market, rebase_contract */
+  ruleType: string;
+  auctionEndTime: string;
+  futureSettlement: boolean; // Whether daily settlement for expiry feature is enabled. Applicable to FUTURES cross.
+  instIdCode: number; // Instrument ID code. For simple binary encoding, must use instIdCode instead of instId.
+  /**
+   * Asset category of the instrument's base asset (see public `Instrument.instCategory` for values).
+   * 1: Crypto, 3: Stocks, 4: Commodities, 5: Forex, 6: Bonds, "": not available
+   */
+  instCategory?: string;
+  posLmtAmt: string; // Maximum position value (USD) for this instrument at the user level. Applicable to SWAP/FUTURES.
+  posLmtPct: string; // Maximum position ratio (e.g., 30 for 30%) a user may hold relative to platform's current total position value. Applicable to SWAP/FUTURES.
+  maxPlatOILmt: string; // Platform-wide maximum position value (USD) for this instrument. Applicable to SWAP/FUTURES.
+  /** Platform-wide maximum position value (coins) for this instrument. Applicable to SWAP/FUTURES. @see 2026-05-19 changelog */
+  maxPlatOICoinLmt?: string;
+  /** Remaining long position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
+  longPosRemainingQuota?: string;
+  /** Remaining short position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
+  shortPosRemainingQuota?: string;
+  groupId?: string; // Instrument trading fee group ID
+  /** ELP maker permission. "0" = not enabled, "1" = enabled but no permission, "2" = enabled with permission */
+  elp?: string;
+  upcChg?: InstrumentUpcomingParamChange[];
+}
+⋮----
+/**
+   * FUTURES label (deprecated: prefer `expTime`; may include this_five_years, next_five_years, ...).
+   */
+⋮----
+/** Deprecated; see `instCategory` on public `Instrument` where used. */
+⋮----
+contTdSwTime: string; // Continuous trading switch time. The switch time from call auction/prequote to continuous trading. Unix timestamp format in milliseconds.
+preMktSwTime: string; // The time premarket swap switched to normal swap. Unix timestamp format in milliseconds. Only applicable to premarket SWAP.
+⋮----
+openType: string; // Open type: fix_price (fix price opening), pre_quote (pre-quote), call_auction (call auction). Only applicable to SPOT/MARGIN.
+⋮----
+tradeQuoteCcyList: string[]; // List of quote currencies available for trading, e.g. ["USD", "USDC"]
+⋮----
+/** Instrument status: live, suspend, rebase (SWAP only), post_only (SWAP only), preopen, test */
+⋮----
+/** Trading rule types: normal, pre_market, rebase_contract */
+⋮----
+futureSettlement: boolean; // Whether daily settlement for expiry feature is enabled. Applicable to FUTURES cross.
+instIdCode: number; // Instrument ID code. For simple binary encoding, must use instIdCode instead of instId.
+/**
+   * Asset category of the instrument's base asset (see public `Instrument.instCategory` for values).
+   * 1: Crypto, 3: Stocks, 4: Commodities, 5: Forex, 6: Bonds, "": not available
+   */
+⋮----
+posLmtAmt: string; // Maximum position value (USD) for this instrument at the user level. Applicable to SWAP/FUTURES.
+posLmtPct: string; // Maximum position ratio (e.g., 30 for 30%) a user may hold relative to platform's current total position value. Applicable to SWAP/FUTURES.
+maxPlatOILmt: string; // Platform-wide maximum position value (USD) for this instrument. Applicable to SWAP/FUTURES.
+/** Platform-wide maximum position value (coins) for this instrument. Applicable to SWAP/FUTURES. @see 2026-05-19 changelog */
+⋮----
+/** Remaining long position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
+⋮----
+/** Remaining short position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
+⋮----
+groupId?: string; // Instrument trading fee group ID
+/** ELP maker permission. "0" = not enabled, "1" = enabled but no permission, "2" = enabled with permission */
+⋮----
+export interface QuickMarginBorrowRepayResult {
+  instId: string;
+  ccy: string;
+  side: 'borrow' | 'repay';
+  amt: string;
+  posSide: string;
+  ts: string;
+}
+⋮----
+export interface QuickMarginBorrowRepayRecord {
+  instId: string;
+  ccy: string;
+  side: 'borrow' | 'repay';
+  accBorrowed: string;
+  amt: string;
+  refId: string;
+  ts: string;
+}
+⋮----
+export interface VIPInterest {
+  ordId: string;
+  ccy: string;
+  interest: string;
+  interestRate: string;
+  liab: string;
+  ts: string;
+}
+⋮----
+export interface VIPLoanOrder {
+  ts: string;
+  nextRefreshTime: string;
+  ccy: string;
+  ordId: string;
+  state: '1' | '2' | '3' | '4' | '5';
+  origRate: string;
+  curRate: string;
+  dueAmt: string;
+  borrowAmt: string;
+  repayAmt: string;
+}
+⋮----
+export interface VIPLoanOrderDetail {
+  amt: string;
+  ccy: string;
+  failReason: string;
+  rate: string;
+  ts: string;
+  type: '1' | '2' | '3' | '4';
+}
+⋮----
+export interface FixedLoanBorrowingLimitDetail {
+  ccy: string;
+  used: string;
+  borrowed: string;
+  availBorrow: string;
+  minBorrow: string;
+  term: string;
+}
+⋮----
+export interface FixedLoanBorrowingLimit {
+  totalBorrowLmt: string;
+  totalAvailBorrow: string;
+  borrowed: string;
+  used: string;
+  availRepay: string;
+  details: FixedLoanBorrowingLimitDetail[];
+  ts: string;
+}
+⋮----
+export interface FixedLoanBorrowQuote {
+  ccy: string;
+  term: string;
+  estAvailBorrow: string;
+  estRate: string;
+  estInterest: string;
+  penaltyInterest: string;
+  ts: string;
+}
+⋮----
+export interface SetMMPConfigResult {
+  instFamily: string;
+  timeInterval: string;
+  frozenInterval: string;
+  qtyLimit: string;
+}
+⋮----
+export interface MMPConfig {
+  frozenInterval: string;
+  instFamily: string;
+  mmpFrozen: boolean;
+  mmpFrozenUntil: string;
+  qtyLimit: string;
+  timeInterval: string;
+}
+⋮----
+export interface BorrowRepayHistoryItem {
+  ccy: string;
+  type: 'auto_borrow' | 'auto_repay' | 'manual_borrow' | 'manual_repay';
+  amt: string;
+  accBorrowed: string;
+  ts: string;
+}
+⋮----
+export interface SetCollateralAssetsResult {
+  type: 'all' | 'custom';
+  ccyList: string[];
+  collateralEnabled: boolean;
+}
+⋮----
+export interface GetCollateralAssetsResult {
+  ccy: string;
+  collateralEnabled: boolean;
+}
+⋮----
+export interface SetSettleCurrencyResult {
+  settleCcy: string;
+}
+⋮----
+export interface SetFeeTypeResult {
+  feeType: string;
+}
+⋮----
+export interface SetTradingConfigResult {
+  type: string; // Trading config type
+  stgyType: string; // Strategy type
+}
+⋮----
+type: string; // Trading config type
+stgyType: string; // Strategy type
+⋮----
+export interface UnmatchedInfo {
+  type: string; // Unmatched information type: spot_mode, futures_mode, isolated_margin, isolated_contract, positions_options, isolated_pending_orders, pending_orders_options, trading_bot, repay_borrowings, loan, delta_risk, collateral_all, risk_unit_type
+  deltaLever?: string; // Delta leverage. Applicable when type is delta_risk
+  ordList?: string[]; // Unmatched order list, order ID. Applicable when type is isolated_pending_orders/pending_orders_options
+  posList?: string[]; // Unmatched position list, position ID. Applicable when type is isolated_margin/isolated_contract/positions_options
+}
+⋮----
+type: string; // Unmatched information type: spot_mode, futures_mode, isolated_margin, isolated_contract, positions_options, isolated_pending_orders, pending_orders_options, trading_bot, repay_borrowings, loan, delta_risk, collateral_all, risk_unit_type
+deltaLever?: string; // Delta leverage. Applicable when type is delta_risk
+ordList?: string[]; // Unmatched order list, order ID. Applicable when type is isolated_pending_orders/pending_orders_options
+posList?: string[]; // Unmatched position list, position ID. Applicable when type is isolated_margin/isolated_contract/positions_options
+⋮----
+export interface PrecheckSetDeltaNeutralResult {
+  unmatchedInfoCheck: UnmatchedInfo[];
+}
+⋮----
+export interface MovePositionLegResultFrom {
+  posId: string;
+  instId: string;
+  px: string;
+  side: string;
+  sz: string;
+  sCode: string;
+  sMsg: string;
+}
+⋮----
+export interface MovePositionLegResultTo {
+  instId: string;
+  px: string;
+  side: string;
+  sz: string;
+  tdMode: string;
+  posSide: string;
+  ccy: string;
+  sCode: string;
+  sMsg: string;
+}
+⋮----
+export interface MovePositionLegResult {
+  from: MovePositionLegResultFrom;
+  to: MovePositionLegResultTo;
+}
+⋮----
+/**
+ * @see POST /api/v5/account/move-positions
+ * @see GET /api/v5/account/move-positions-history
+ */
+export interface MovePositionsResult {
+  clientId: string;
+  blockTdId: string;
+  state: 'filled' | 'failed' | 'pending' | string;
+  ts: string;
+  fromAcct: string;
+  toAcct: string;
+  legs: MovePositionLegResult[];
+}
+
+================
 File: src/rest-client.ts
 ================
 import { ASSET_BILL_TYPE } from './constants/funding.js';
@@ -8800,11 +8346,13 @@ import {
   GetFixedLoanBorrowQuoteRequest,
   GetHistoricPositionParams,
   GetInstrumentsRequest,
+  GetMovePositionsHistoryRequest,
   GetPositionsParams,
   GetQuickMarginBorrowRepayHistoryRequest,
   GetVIPInterestRequest,
   GetVIPLoanOrderDetailRequest,
   GetVIPLoanOrderListRequest,
+  MovePositionsRequest,
   PositionBuilderRequest,
   PrecheckSetDeltaNeutralRequest,
   QuickMarginBorrowRepayRequest,
@@ -8893,6 +8441,7 @@ import {
   GetEventContractMarketsRequest,
   GetEventContractSeriesRequest,
   GetHistoricalMarketDataRequest,
+  GetInsuranceFundRequest,
   GetOptionTradesRequest,
   GetPremiumHistoryRequest,
   GetTopTradersContractLongShortRatioRequest,
@@ -8993,6 +8542,7 @@ import {
   InterestRate,
   MaxWithdrawal,
   MMPConfig,
+  MovePositionsResult,
   PrecheckSetDeltaNeutralResult,
   QuickMarginBorrowRepayRecord,
   QuickMarginBorrowRepayResult,
@@ -9152,6 +8702,7 @@ import {
   FundingRateHistory,
   IndexTicker,
   Instrument,
+  InsuranceFund,
   InterestRateAndLoanQuota,
   MarketDataHistoryResult,
   OptionTrade,
@@ -9303,6 +8854,21 @@ getMaxAvailableTradableAmount(params: {
 changePositionMargin(
     params: ChangePositionMarginRequest,
 ): Promise<AccountChangeMarginResult[]>
+⋮----
+/**
+   * Move positions between accounts under the same master account (VIP6+).
+   * TradeFi positions are not supported (error 70004).
+   * @see POST /api/v5/account/move-positions — 2026-05-15 changelog
+   */
+movePositions(params: MovePositionsRequest): Promise<MovePositionsResult[]>
+⋮----
+/**
+   * Move position history for the last 3 days (VIP6+).
+   * @see GET /api/v5/account/move-positions-history
+   */
+getMovePositionsHistory(
+    params?: GetMovePositionsHistoryRequest,
+): Promise<MovePositionsResult[]>
 ⋮----
 getLeverage(params: {
     instId?: string;
@@ -10409,7 +9975,7 @@ cancelSpreadAllAfter(params: { timeOut: string }): Promise<
 getInstruments(params: GetInstrumentsRequest): Promise<Instrument[]>
 ⋮----
 /**
-   * Prediction / event contract series. Auth required (read).
+   * Prediction / event contract series. Public (no auth required since 2026-05-19).
    * @see GET /api/v5/public/event-contract/series
    */
 getEventContractSeries(
@@ -10417,7 +9983,7 @@ getEventContractSeries(
 ): Promise<EventContractSeries[]>
 ⋮----
 /**
-   * Events for a series. Auth required (read).
+   * Events for a series. Public (no auth required since 2026-05-19).
    * @see GET /api/v5/public/event-contract/events
    */
 getEventContractEvents(
@@ -10425,7 +9991,7 @@ getEventContractEvents(
 ): Promise<EventContractEvent[]>
 ⋮----
 /**
-   * Markets for events. Auth required (read).
+   * Markets for events. Public (no auth required since 2026-05-19).
    * @see GET /api/v5/public/event-contract/markets
    */
 getEventContractMarkets(
@@ -10472,7 +10038,7 @@ getVIPInterestRateAndLoanQuota(params: any): Promise<any[]>
 ⋮----
 getUnderlying(params: any): Promise<any[]>
 ⋮----
-getInsuranceFund(params: any): Promise<any[]>
+getInsuranceFund(params?: GetInsuranceFundRequest): Promise<InsuranceFund[]>
 ⋮----
 getUnitConvert(params: UnitConvertRequest): Promise<UnitConvertData[]>
 ⋮----
@@ -10644,11 +10210,15 @@ getAssetBillsHistoric(params?: {
     ccy?: string;
     type?: `${ASSET_BILL_TYPE}`;
     clientId?: string;
+    /** Third-party custody type. Defaults to 1 (Copper) if not specified. @see 2026-06-05 changelog */
+    thirdPartyType?: '1' | '2' | '5' | '6';
     after?: numberInString;
     before?: numberInString;
     limit?: numberInString;
     pagingType?: '0' | '1';
 }): Promise<AssetBillDetails[]>
+⋮----
+/** Third-party custody type. Defaults to 1 (Copper) if not specified. @see 2026-06-05 changelog */
 ⋮----
 getLightningDeposits(params: {
     ccy: string;
@@ -11087,11 +10657,621 @@ createSubAccountAPIKey(params: {
 }): Promise<any[]>
 
 ================
+File: README.md
+================
+# Node.js & Typescript OKX (OKEX) API & WebSocket SDK
+
+[![E2E Tests](https://github.com/tiagosiebler/okx-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/okx-api/actions/workflows/e2etest.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/okx-api)
+[![npm downloads](https://img.shields.io/npm/dt/okx-api)][1]
+[![npm version](https://img.shields.io/npm/v/okx-api)][1]
+[![npm size](https://img.shields.io/bundlephobia/min/okx-api/latest)][1]
+[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/okx-api)][1]
+[![CodeFactor](https://www.codefactor.io/repository/github/tiagosiebler/okx-api/badge)](https://www.codefactor.io/repository/github/tiagosiebler/okx-api)
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/okx-api">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/okx-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/tiagosiebler/okx-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+    </picture>
+  </a>
+</p>
+
+[1]: https://www.npmjs.com/package/okx-api
+
+> [!TIP]
+> Upcoming change: As part of the [Siebly.io](https://siebly.io/?ref=ghokx) brand, this SDK will soon be hosted under the [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
+
+Complete, updated & performant Node.js SDK for the OKX(OKEX) APIs and WebSockets:
+
+- Complete integration with OKX REST APIs, WebSockets & WebSocket APIs.
+- TypeScript support (with type declarations for most API requests & responses).
+- Over 100 end-to-end tests making real API calls & WebSocket connections, validating any changes before they reach npm.
+- Supports all available OKX regions:
+  - OKX Global (www.okx.com), by default.
+  - OKX EEA (my.okx.com), by setting `market: 'EEA'`.
+  - OKX US (app.okx.com), by setting `market: 'US'`.
+- Actively maintained with a modern, promise-driven interface.
+- Robust WebSocket integration
+  - Configurable connection heartbeats (automatically detect failing connections).
+  - Automatic reconnect then resubscribe workflows.
+  - Automatic authentication and heartbeat handling.
+- Supports WebSocket API in all supported regions & product groups:
+  - Use the WebsocketClient's event-driven `sendWSAPIRequest()` method, or;
+  - Use the WebsocketAPIClient for a REST-like experience.
+    - Use the WebSocket API like a REST API!
+    - Automatic routing to business vs private WebSocket endpoints.
+    - End to end types.
+    - See [examples/ws-api-client.ts](./examples/ws-api-client.ts) for a demonstration.
+- Browser support (via webpack bundle - see "Browser Usage" below).
+- QuickStart Guide: https://siebly.io/sdk/okx/javascript
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Issues & Discussion](#issues--discussion)
+- [Related Projects](#related-projects)
+- [Documentation](#documentation)
+- [Contributions & Thanks](#contributions--thanks)
+- [Structure](#structure)
+- [Usage](#usage)
+  - [REST Client](#rest-client)
+    - [Requests & Responses](#requests--responses)
+    - [Example](#example)
+  - [WebSockets](#websockets)
+    - [Sending Orders via WebSockets](#sending-orders-via-websockets)
+    - [Receiving Realtime Data](#receiving-realtime-data)
+    - [Public Events](#public-events)
+    - [Private Events](#private-events)
+- [Browser/Frontend Usage](#browserfrontend-usage)
+  - [Import](#import)
+  - [Webpack](#webpack)
+- [Use with LLMs & AI](#use-with-llms--ai)
+- [Contributions & Pull Requests](#contributions--pull-requests)
+- [Used By](#used-by)
+- [Star History](#star-history)
+
+## Installation
+
+```bash
+npm install okx-api
+```
+
+## Issues & Discussion
+
+- Issues? Check the [issues tab](https://github.com/tiagosiebler/okx-api/issues).
+- Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
+- Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
+
+<!-- template_related_projects -->
+
+## Related Projects
+
+Check out our JavaScript/TypeScript/Node.js SDKs & Projects:
+
+- Visit our website: [https://Siebly.io](https://siebly.io/?ref=gh)
+- Try our REST API & WebSocket SDKs published on npmjs:
+  - [Bybit Node.js SDK: bybit-api](https://www.npmjs.com/package/bybit-api)
+  - [Kraken Node.js SDK: @siebly/kraken-api](https://www.npmjs.com/package/@siebly/kraken-api)
+  - [OKX Node.js SDK: okx-api](https://www.npmjs.com/package/okx-api)
+  - [Binance Node.js SDK: binance](https://www.npmjs.com/package/binance)
+  - [Gate (gate.com) Node.js SDK: gateio-api](https://www.npmjs.com/package/gateio-api)
+  - [Bitget Node.js SDK: bitget-api](https://www.npmjs.com/package/bitget-api)
+  - [Kucoin Node.js SDK: kucoin-api](https://www.npmjs.com/package/kucoin-api)
+  - [Coinbase Node.js SDK: coinbase-api](https://www.npmjs.com/package/coinbase-api)
+  - [Bitmart Node.js SDK: bitmart-api](https://www.npmjs.com/package/bitmart-api)
+- Try my misc utilities:
+  - [OrderBooks Node.js: orderbooks](https://www.npmjs.com/package/orderbooks)
+  - [Crypto Exchange Account State Cache: accountstate](https://www.npmjs.com/package/accountstate)
+- Check out my examples:
+  - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
+  <!-- template_related_projects_end -->
+
+## Documentation
+
+Most methods accept JS objects. These can be populated using parameters specified by okx's API documentation, or check the type definition in the rest-client class methods.
+
+- [RestClient](src/rest-client.ts)
+- [OKX API Documentation](https://www.okx.com/docs-v5/en/#rest-api)
+- [REST Endpoint Function List](./docs/endpointFunctionList.md)
+
+## Contributions & Thanks
+
+Support my efforts to make algo trading accessible to all - register with my referral links:
+
+- [Bybit](https://www.bybit.com/en-US/register?affiliate_id=9410&language=en-US&group_id=0&group_type=1)
+- [Binance](https://www.binance.com/en/register?ref=20983262)
+- [OKX](https://www.okx.com/join/18504944)
+
+For more ways to give thanks & support my efforts, visit [Contributions & Thanks](https://github.com/tiagosiebler/awesome-crypto-examples/wiki/Contributions-&-Thanks)!
+
+## Structure
+
+This project uses typescript. Resources are stored in 3 key structures:
+
+- [src](./src) - the whole connector written in typescript
+- [lib](./lib) - the javascript version of the project (compiled from typescript). This should not be edited directly, as it will be overwritten with each release. This is also the version published to npm.
+- [dist](./dist) - the packed bundle of the project for use in browser environments (manual, using webpack).
+- [examples](./examples) - some implementation examples & demonstrations. Contributions are welcome!
+
+---
+
+## Usage
+
+Create API credentials at okx
+
+- [OKX/account/API](https://www.okx.com/account/my-api)
+
+## REST Client
+
+### Requests & Responses
+
+- If your IDE doesn't have IntelliSense, check the [rest-client.ts](./src/rest-client.ts) for a list of methods, params & return types.
+- Requests follow the same ordering and format as the categories in the [API docs](https://www.okx.com/docs-v5/en/#rest-api).
+- Responses are parsed automatically for less nesting. Error responses are thrown in full:
+  - If the response looks successful (HTTP 200 and "code" in the response body === "0"), only the `data` property is directly (without the `code`, `data` & `msg` properties).
+  - If the response looks like an error (HTTP error OR the "code" property in the response does not equal "0"), the full response is thrown (including `code` and `msg` properties). See the interface for [APIResponse<T>](./src/types/rest/shared.ts).
+
+### Example
+
+```ts
+import { RestClient } from 'okx-api';
+
+const client = new RestClient({
+  apiKey: 'apiKeyHere',
+  apiSecret: 'apiSecretHere',
+  apiPass: 'apiPassHere',
+  // For Global users (www.okx.com), you don't need to set the market.
+  // It will use global by default.
+  // Not needed: market: 'GLOBAL',
+
+  // For EEA users (my.okx.com), set market to "EEA":
+  // market: 'EEA',
+
+  // For US users (app.okx.com), set market to "US":
+  // market: 'US',
+});
+
+// Submit a buy and sell market order
+(async () => {
+  try {
+    const allBalances = await client.getBalance();
+    console.log('All balances: ', allBalances);
+
+    const buyResult = await client.submitOrder({
+      instId: 'BTC-USDT',
+      ordType: 'market',
+      side: 'buy',
+      sz: '0.1',
+      tdMode: 'cash',
+      tgtCcy: 'base_ccy',
+    });
+    console.log('buy order result: ', buyResult);
+
+    const sellResult = await client.submitOrder({
+      instId: 'BTC-USDT',
+      ordType: 'market',
+      side: 'sell',
+      sz: '0.1',
+      tdMode: 'cash',
+      tgtCcy: 'base_ccy',
+    });
+    console.log('Sell order result: ', sellResult);
+  } catch (e) {
+    console.error('request failed: ', e);
+  }
+})();
+```
+
+## WebSockets
+
+This connector includes a high-performance Node.js, TypeScript & JavaScript WebSocket client for the OKX public & private WebSocket, including the OKX WebSocket API for order placement. API credentials are optional unless private streams will be used (such as account order updates).
+
+- If your IDE doesn't have IntelliSense, check the [websocket-client.ts](./src/websocket-client.ts) for a list of methods, params & return types.
+- When subscribing to channels, only the "args" should be passed as an object or array when calling the websocket client subcribe() function: [API docs](https://www.okx.com/docs-v5/en/#websocket-api-subscribe).
+- TypeScript recommended (but it is not required) for a richer experience:
+  ![typescript-subscribe](./docs/images/subscribe-with-typescript.gif)
+- The ws client will automatically open connections as needed when subscribing to a channel.
+- If the connection is lost for any reason, the ws client will detect this (via the connection heartbeats). It will then:
+  - Automatically teardown the dead connection.
+  - Automatically respawn a fresh connection.
+  - Automatically reauthenticate, if using private channels.
+  - Automatically resubscribe to previously subscribed topics.
+  - Resume producing events as before, without extra handling needed in your logic.
+- The ws client will automatically authenticate if accounts are provided and a private channel is subscribed to.
+- Up to 100 accounts are supported on the private connection, as per the [API docs](https://www.okx.com/docs-v5/en/#websocket-api-login). Authentication is automatic if accounts are provided.
+- For examples in using the websocket client, check the examples in the repo:
+  - Private channels (account data): [examples/ws-private.ts](./examples/ws-private.ts)
+  - Public chanels (market data): [examples/ws-public.ts](./examples/ws-public.ts)
+  - These examples are written in TypeScript, so can be executed with ts-node for easy testing:
+    `ts-node examples/ws-private.ts`
+  - Or convert them to javascript:
+    - Change the `import { ... } from 'okx-api'` to `const { ... } = require('okx-api');`
+    - Rename the file to `ws-private.js`
+    - And execute with node: `node examples/ws-private.js`
+
+### Sending orders via WebSockets
+
+OKX supports some order management capabilities via a persisted WebSocket connection. This SDK supports this with two convenient approaches.
+
+The recommended route is to use the dedicated WebsocketAPIClient class, included with this SDK:
+
+- Dedicated functions for every available WebSocket API operation
+- Fully typed requests and responses
+- Asynchronous promisified wrapper around WS API commands.
+
+It looks & feels like a REST API client, but uses WebSockets, via the WebsocketClient's sendWSAPIRequest method (which you can use directly if you prefer).
+
+A simple example is below but for a more thorough example, check the example here: [./examples/ws-api-client.ts](./examples/ws-api-client.ts).
+
+```typescript
+import { WebsocketAPIClient } from 'okx-api';
+// or if you prefer require:
+// const { WebsocketAPIClient } = require("okx-api");
+
+// For private events, all 3 of the following are required (per account):
+const API_KEY = process.env.API_KEY_COM;
+const API_SECRET = process.env.API_SECRET_COM;
+const API_PASSPHRASE = process.env.API_PASSPHRASE_COM;
+
+// If running from CLI in unix, you can pass env vars as such:
+// API_KEY_COM='lkm12n3-2ba3-1mxf-fn13-lkm12n3a' API_SECRET_COM='035B2B9637E1BDFFEE2646BFBDDB8CE4' API_PASSPHRASE_COM='ComplexPa$$!23$5^' ts-node examples/ws-private.ts
+
+const wsClient = new WebsocketAPIClient({
+  // For Global users (www.okx.com), you don't need to set the market.
+  // It will use global by default.
+  // Not needed: market: 'GLOBAL',
+
+  // For EEA users (my.okx.com), set market to "EEA":
+  // market: 'EEA',
+
+  // For US users (app.okx.com), set market to "US":
+  // market: 'US',
+
+  accounts: [
+    {
+      apiKey: API_KEY,
+      apiSecret: API_SECRET,
+      apiPass: API_PASSPHRASE,
+    },
+  ],
+});
+
+async function start() {
+  // Optional: prepare the WebSocket API connection in advance.
+  // This happens automatically but you can do this early before making any API calls, to prevent delays from a cold start.
+  // await wsClient.connectWSAPI();
+
+  /**
+   * OKX's WebSocket API be used like a REST API, through this SDK's WebsocketAPIClient. The WebsocketAPIClient is a utility class wrapped around WebsocketClient's sendWSAPIRequest() capabilities.
+   *
+   * Each request sent via the WebsocketAPIClient will automatically:
+   * - route via the active WS API connection
+   * - return a Promise, which automatically resolves/rejects when a matching response is received
+   */
+
+  /**
+   * Place Order
+   * https://www.okx.com/docs-v5/en/#order-book-trading-trade-ws-place-order
+   */
+  try {
+    const res = await wsClient.submitNewOrder({
+      instId: 'BTC-USDT',
+      tdMode: 'cash',
+      side: 'buy',
+      ordType: 'market',
+      sz: '100',
+    });
+    /**
+      const res = {
+        id: '2',
+        op: 'order',
+        code: '1',
+        msg: '',
+        data: [
+          {
+            tag: '159881cb7207BCDE',
+            ts: '1753714603721',
+            ordId: '',
+            clOrdId: '',
+            sCode: '51008',
+            sMsg: 'Order failed. Insufficient USDT balance in account.'
+          }
+        ],
+        inTime: '1753714603720755',
+        outTime: '1753714603721942',
+        wsKey: 'prodPrivate',
+        isWSAPIResponse: false
+      }
+
+      const res =  {
+        id: '2',
+        op: 'order',
+        code: '1',
+        msg: '',
+        data: [
+          {
+            tag: '159881cb7207BCDE',
+            ts: '1753714567149',
+            ordId: '',
+            clOrdId: '',
+            sCode: '51010',
+            sMsg: "You can't complete this request under your current account mode."
+          }
+        ],
+        inTime: '1753714567149196',
+        outTime: '1753714567149913',
+        wsKey: 'prodPrivate',
+        isWSAPIResponse: false
+      }
+     */
+
+    console.log(new Date(), 'WS API "submitNewOrder()" result: ', res);
+  } catch (e) {
+    console.error(new Date(), 'Exception with WS API "submitNewOrder()": ', e);
+  }
+
+  /**
+   * Submit multiple orders in a batch
+   * https://www.okx.com/docs-v5/en/#order-book-trading-trade-ws-place-multiple-orders
+   */
+  try {
+    const res = await wsClient.submitMultipleOrders([
+      {
+        instId: 'BTC-USDT',
+        tdMode: 'cash',
+        side: 'buy',
+        ordType: 'market',
+        sz: '100',
+      },
+      {
+        instId: 'BTC-USDT',
+        tdMode: 'cash',
+        side: 'buy',
+        ordType: 'market',
+        sz: '50',
+      },
+    ]);
+    console.log(new Date(), 'WS API "submitMultipleOrders()" result: ', res);
+  } catch (e) {
+    console.error(
+      new Date(),
+      'Exception with WS API "submitMultipleOrders()": ',
+      e,
+    );
+  }
+}
+
+start();
+```
+
+### Receiving realtime data
+
+The below example demonstrates connecting as a consumer, to receive WebSocket events from OKX, using the included WebsocketClient:
+
+```javascript
+import { WebsocketClient } from 'okx-api';
+// or if you prefer require:
+// const { WebsocketClient } = require("okx-api");
+
+// For private events, all 3 of the following are required (per account):
+const API_KEY = process.env.API_KEY_COM;
+const API_SECRET = process.env.API_SECRET_COM;
+const API_PASSPHRASE = process.env.API_PASSPHRASE_COM;
+
+// If running from CLI in unix, you can pass env vars as such:
+// API_KEY_COM='lkm12n3-2ba3-1mxf-fn13-lkm12n3a' API_SECRET_COM='035B2B9637E1BDFFEE2646BFBDDB8CE4' API_PASSPHRASE_COM='ComplexPa$$!23$5^' ts-node examples/ws-private.ts
+
+// Note the single quotes, preventing special characters such as $ from being incorrectly passed
+
+const wsClient = new WebsocketClient({
+  // For Global users (www.okx.com), you don't need to set the market.
+  // It will use global by default.
+  // Not needed: market: 'GLOBAL',
+
+  // For EEA users (my.okx.com), set market to "EEA":
+  // market: 'EEA',
+
+  // For US users (app.okx.com), set market to "US":
+  // market: 'US',
+
+  accounts: [
+    // For private topics, include one or more accounts in an array. Otherwise only public topics will work
+    {
+      apiKey: API_KEY,
+      apiSecret: API_SECRET,
+      apiPass: API_PASSPHRASE,
+    },
+    // {
+    //   apiKey: 'yourApiKeyHere',
+    //   apiSecret: 'yourApiSecretHere',
+    //   apiPass: 'yourApiPassHere',
+    // },
+    // {
+    //   apiKey: 'anotherAccountKey',
+    //   apiSecret: 'anotherAccountSecret',
+    //   apiPass: 'anotherAccountPass',
+    // },
+  ],
+});
+
+// Raw data will arrive on the 'update' event
+wsClient.on('update', (data) => {
+  console.log('ws update (raw data received)', JSON.stringify(data));
+});
+
+wsClient.on('open', (data) => {
+  console.log('connection opened open:', data.wsKey);
+});
+
+// Replies (e.g. authenticating or subscribing to channels) will arrive on the 'response' event
+wsClient.on('response', (data) => {
+  // console.log('ws response: ', JSON.stringify(data, null, 2));
+  console.log('ws response: ', JSON.stringify(data));
+});
+
+wsClient.on('reconnect', ({ wsKey }) => {
+  console.log('ws automatically reconnecting.... ', wsKey);
+});
+wsClient.on('reconnected', (data) => {
+  console.log('ws has reconnected ', data?.wsKey);
+});
+wsClient.on('exception', (data) => {
+  console.error('ws exception: ', data);
+});
+
+/**
+ * Simply call subscribe to request the channels that you're interested in.
+ *
+ * If authentication is required, the WSClient will automatically authenticate with the available credentials.
+ */
+
+// Subscribe one event at a time:
+wsClient.subscribe({
+  channel: 'account',
+});
+
+// OR, combine multiple subscription events into one request using an array instead of an object:
+wsClient.subscribe([
+  {
+    channel: 'account',
+  },
+  {
+    channel: 'positions',
+    instType: 'ANY',
+  },
+]);
+
+// Public topics, for comparison. These do not require authentication / api keys:
+wsClient.subscribe([
+  {
+    channel: 'instruments',
+    instType: 'SPOT',
+  },
+  {
+    channel: 'instruments',
+    instType: 'FUTURES',
+  },
+  {
+    channel: 'tickers',
+    instId: 'LTC-BTC',
+  },
+]);
+```
+
+#### Public Events
+
+See [examples/ws-public.ts](./examples/ws-public.ts) for a full example:
+
+![typescript-events-public](./docs/images/subscribe-events-public.gif)
+
+#### Private Events
+
+See [examples/ws-private.ts](./examples/ws-private.ts) for a full example:
+
+![typescript-events](./docs/images/subscribe-events.gif)
+
+## Browser/Frontend Usage
+
+### Import
+
+This is the "modern" way, allowing the package to be directly imported into frontend projects with full typescript support.
+
+1. Install these dependencies
+   ```sh
+   npm install crypto-browserify stream-browserify
+   ```
+2. Add this to your `tsconfig.json`
+   ```json
+   {
+     "compilerOptions": {
+       "paths": {
+         "crypto": [
+           "./node_modules/crypto-browserify"
+         ],
+         "stream": [
+           "./node_modules/stream-browserify"
+         ]
+   }
+   ```
+3. Declare this in the global context of your application (ex: in polyfills for angular)
+   ```js
+   (window as any).global = window;
+   ```
+
+### Webpack
+
+This is the "old" way of using this package on webpages. This will build a minified js bundle that can be pulled in using a script tag on a website.
+
+Build a bundle using webpack:
+
+- `npm install`
+- `npm build`
+- `npm pack`
+
+The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
+
+## Use with LLMs & AI
+
+This SDK includes a bundled `llms.txt` file in the root of the repository. If you're developing with LLMs, use the included `llms.txt` with your LLM - it will significantly improve the LLMs understanding of how to correctly use this SDK.
+
+This file contains AI optimised structure of all the functions in this package, and their parameters for easier use with any learning models or artificial intelligence.
+
+---
+
+<!-- template_contributions -->
+
+### Contributions & Thanks
+
+Have my projects helped you? Share the love, there are many ways you can show your thanks:
+
+- Star & share my projects.
+- Are my projects useful? Sponsor me on Github and support my effort to maintain & improve them: https://github.com/sponsors/tiagosiebler
+- Have an interesting project? Get in touch & invite me to it.
+- Or buy me all the coffee:
+  - ETH(ERC20): `0xA3Bda8BecaB4DCdA539Dc16F9C54a592553Be06C` <!-- metamask -->
+- Sign up with my referral links:
+  - OKX (receive a 20% fee discount!): https://www.okx.com/join/42013004
+  - Binance (receive a 20% fee discount!): https://accounts.binance.com/register?ref=OKFFGIJJ
+  - HyperLiquid (receive a 4% fee discount!): https://app.hyperliquid.xyz/join/SDK
+  - Gate: https://www.gate.io/signup/NODESDKS?ref_type=103
+
+<!---
+old ones:
+  - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
+  - BTC(SegWit): `bc1ql64wr9z3khp2gy7dqlmqw7cp6h0lcusz0zjtls`
+  - ETH(ERC20): `0xe0bbbc805e0e83341fadc210d6202f4022e50992`
+  - USDT(TRC20): `TA18VUywcNEM9ahh3TTWF3sFpt9rkLnnQa
+  - gate: https://www.gate.io/signup/AVNNU1WK?ref_type=103
+
+-->
+<!-- template_contributions_end -->
+
+## Contributions & Pull Requests
+
+Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.
+
+## Used By
+
+The following represents some of the known public projects that use this SDK on GitHub:
+
+[![Repository Users Preview Image](https://dependents.info/tiagosiebler/okx-api/image)](https://github.com/tiagosiebler/okx-api/network/dependents)
+
+<!-- template_star_history -->
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
+
+<!-- template_star_history_end -->
+
+================
 File: package.json
 ================
 {
   "name": "okx-api",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Complete Node.js SDK for OKX's REST APIs and WebSockets, with TypeScript & end-to-end tests",
   "scripts": {
     "test": "jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "okx-api",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "okx-api",
-      "version": "3.1.5",
+      "version": "3.1.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okx-api",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Complete Node.js SDK for OKX's REST APIs and WebSockets, with TypeScript & end-to-end tests",
   "scripts": {
     "test": "jest",
@@ -58,7 +58,7 @@
     "webpack": "^5.74.0",
     "webpack-bundle-analyzer": "^4.6.1",
     "webpack-cli": "^4.10.0"
-  },  
+  },
   "keywords": [
     "okx",
     "okx api",

--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -8,11 +8,13 @@ import {
   GetFixedLoanBorrowQuoteRequest,
   GetHistoricPositionParams,
   GetInstrumentsRequest,
+  GetMovePositionsHistoryRequest,
   GetPositionsParams,
   GetQuickMarginBorrowRepayHistoryRequest,
   GetVIPInterestRequest,
   GetVIPLoanOrderDetailRequest,
   GetVIPLoanOrderListRequest,
+  MovePositionsRequest,
   PositionBuilderRequest,
   PrecheckSetDeltaNeutralRequest,
   QuickMarginBorrowRepayRequest,
@@ -101,6 +103,7 @@ import {
   GetEventContractMarketsRequest,
   GetEventContractSeriesRequest,
   GetHistoricalMarketDataRequest,
+  GetInsuranceFundRequest,
   GetOptionTradesRequest,
   GetPremiumHistoryRequest,
   GetTopTradersContractLongShortRatioRequest,
@@ -201,6 +204,7 @@ import {
   InterestRate,
   MaxWithdrawal,
   MMPConfig,
+  MovePositionsResult,
   PrecheckSetDeltaNeutralResult,
   QuickMarginBorrowRepayRecord,
   QuickMarginBorrowRepayResult,
@@ -360,6 +364,7 @@ import {
   FundingRateHistory,
   IndexTicker,
   Instrument,
+  InsuranceFund,
   InterestRateAndLoanQuota,
   MarketDataHistoryResult,
   OptionTrade,
@@ -599,6 +604,25 @@ export class RestClient extends BaseRestClient {
     params: ChangePositionMarginRequest,
   ): Promise<AccountChangeMarginResult[]> {
     return this.postPrivate('/api/v5/account/position/margin-balance', params);
+  }
+
+  /**
+   * Move positions between accounts under the same master account (VIP6+).
+   * TradeFi positions are not supported (error 70004).
+   * @see POST /api/v5/account/move-positions — 2026-05-15 changelog
+   */
+  movePositions(params: MovePositionsRequest): Promise<MovePositionsResult[]> {
+    return this.postPrivate('/api/v5/account/move-positions', params);
+  }
+
+  /**
+   * Move position history for the last 3 days (VIP6+).
+   * @see GET /api/v5/account/move-positions-history
+   */
+  getMovePositionsHistory(
+    params?: GetMovePositionsHistoryRequest,
+  ): Promise<MovePositionsResult[]> {
+    return this.getPrivate('/api/v5/account/move-positions-history', params);
   }
 
   getLeverage(params: {
@@ -2176,33 +2200,33 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
-   * Prediction / event contract series. Auth required (read).
+   * Prediction / event contract series. Public (no auth required since 2026-05-19).
    * @see GET /api/v5/public/event-contract/series
    */
   getEventContractSeries(
     params?: GetEventContractSeriesRequest,
   ): Promise<EventContractSeries[]> {
-    return this.getPrivate('/api/v5/public/event-contract/series', params);
+    return this.get('/api/v5/public/event-contract/series', params);
   }
 
   /**
-   * Events for a series. Auth required (read).
+   * Events for a series. Public (no auth required since 2026-05-19).
    * @see GET /api/v5/public/event-contract/events
    */
   getEventContractEvents(
     params: GetEventContractEventsRequest,
   ): Promise<EventContractEvent[]> {
-    return this.getPrivate('/api/v5/public/event-contract/events', params);
+    return this.get('/api/v5/public/event-contract/events', params);
   }
 
   /**
-   * Markets for events. Auth required (read).
+   * Markets for events. Public (no auth required since 2026-05-19).
    * @see GET /api/v5/public/event-contract/markets
    */
   getEventContractMarkets(
     params: GetEventContractMarketsRequest,
   ): Promise<EventContractMarket[]> {
-    return this.getPrivate('/api/v5/public/event-contract/markets', params);
+    return this.get('/api/v5/public/event-contract/markets', params);
   }
 
   getDeliveryExerciseHistory(params: any): Promise<any[]> {
@@ -2275,7 +2299,7 @@ export class RestClient extends BaseRestClient {
     return this.get('/api/v5/public/underlying', params);
   }
 
-  getInsuranceFund(params: any): Promise<any[]> {
+  getInsuranceFund(params?: GetInsuranceFundRequest): Promise<InsuranceFund[]> {
     return this.get('/api/v5/public/insurance-fund', params);
   }
 
@@ -2544,6 +2568,8 @@ export class RestClient extends BaseRestClient {
     ccy?: string;
     type?: `${ASSET_BILL_TYPE}`;
     clientId?: string;
+    /** Third-party custody type. Defaults to 1 (Copper) if not specified. @see 2026-06-05 changelog */
+    thirdPartyType?: '1' | '2' | '5' | '6';
     after?: numberInString;
     before?: numberInString;
     limit?: numberInString;

--- a/src/types/rest/request/account.ts
+++ b/src/types/rest/request/account.ts
@@ -196,3 +196,36 @@ export interface BillsHistoryArchiveRequest {
   /** Comma-separated bill type ids, e.g. 1,2,3. If omitted, all types. */
   type?: string;
 }
+
+export interface MovePositionLegFrom {
+  posId: string;
+  side: 'buy' | 'sell';
+  sz: string;
+}
+
+export interface MovePositionLegTo {
+  tdMode?: 'cross' | 'isolated';
+  posSide?: PositionSide;
+  ccy?: string;
+}
+
+export interface MovePositionLeg {
+  from: MovePositionLegFrom;
+  to: MovePositionLegTo;
+}
+
+export interface MovePositionsRequest {
+  fromAcct: string;
+  toAcct: string;
+  legs: MovePositionLeg[];
+  clientId: string;
+}
+
+export interface GetMovePositionsHistoryRequest {
+  blockTdId?: string;
+  clientId?: string;
+  beginTs?: string;
+  endTs?: string;
+  limit?: string;
+  state?: 'filled' | 'pending';
+}

--- a/src/types/rest/request/public.ts
+++ b/src/types/rest/request/public.ts
@@ -109,3 +109,17 @@ export interface GetEventContractMarketsRequest {
   before?: string;
   after?: string;
 }
+
+export interface GetInsuranceFundRequest {
+  instType?: string;
+  type?:
+    | 'liquidation_balance_deposit'
+    | 'bankruptcy_loss'
+    | 'platform_revenue'
+    | 'adl';
+  instFamily?: string;
+  ccy?: string;
+  before?: string;
+  after?: string;
+  limit?: string;
+}

--- a/src/types/rest/response/private-account.ts
+++ b/src/types/rest/response/private-account.ts
@@ -295,6 +295,7 @@ export interface FeeGroup {
   taker: string;
   maker: string;
   groupId: string;
+  elpMaker?: string;
 }
 
 export interface AccountFeeRate {
@@ -441,6 +442,8 @@ export interface AccountInstrument {
   posLmtAmt: string; // Maximum position value (USD) for this instrument at the user level. Applicable to SWAP/FUTURES.
   posLmtPct: string; // Maximum position ratio (e.g., 30 for 30%) a user may hold relative to platform's current total position value. Applicable to SWAP/FUTURES.
   maxPlatOILmt: string; // Platform-wide maximum position value (USD) for this instrument. Applicable to SWAP/FUTURES.
+  /** Platform-wide maximum position value (coins) for this instrument. Applicable to SWAP/FUTURES. @see 2026-05-19 changelog */
+  maxPlatOICoinLmt?: string;
   /** Remaining long position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
   longPosRemainingQuota?: string;
   /** Remaining short position value (USD) the user is permitted to open. Applicable to SWAP/FUTURES. */
@@ -587,4 +590,41 @@ export interface UnmatchedInfo {
 
 export interface PrecheckSetDeltaNeutralResult {
   unmatchedInfoCheck: UnmatchedInfo[];
+}
+
+export interface MovePositionLegResultFrom {
+  posId: string;
+  instId: string;
+  px: string;
+  side: string;
+  sz: string;
+  sCode: string;
+  sMsg: string;
+}
+
+export interface MovePositionLegResultTo {
+  instId: string;
+  px: string;
+  side: string;
+  sz: string;
+  tdMode: string;
+  posSide: string;
+  ccy: string;
+  sCode: string;
+  sMsg: string;
+}
+
+export interface MovePositionLegResult {
+  from: MovePositionLegResultFrom;
+  to: MovePositionLegResultTo;
+}
+
+export interface MovePositionsResult {
+  clientId: string;
+  blockTdId: string;
+  state: 'filled' | 'failed' | 'pending' | string;
+  ts: string;
+  fromAcct: string;
+  toAcct: string;
+  legs: MovePositionLegResult[];
 }

--- a/src/types/rest/response/private-trade.ts
+++ b/src/types/rest/response/private-trade.ts
@@ -35,6 +35,7 @@ export interface OrderResult {
   tag: string;
   ts: string;
   sCode: numberInString;
+  subCode?: string;
   sMsg: string;
 }
 
@@ -42,6 +43,7 @@ export interface CancelledOrderResult {
   clOrdId: string;
   ordId: string;
   sCode: string;
+  subCode?: string;
   sMsg: string;
 }
 
@@ -50,6 +52,7 @@ export interface AmendedOrder {
   ordId: string;
   reqId: string;
   sCode: string;
+  subCode?: string;
   sMsg: string;
 }
 export interface ClosedPositions {

--- a/src/types/rest/response/public-data.ts
+++ b/src/types/rest/response/public-data.ts
@@ -201,6 +201,28 @@ export interface PublicFundingRate {
   ts: string;
 }
 
+export interface InsuranceFundDetail {
+  ccy?: string;
+  bal?: string;
+  amt?: string;
+  type?: string;
+  maxBal?: string;
+  maxBalTs?: string;
+  decRate?: string;
+  adlType?: string;
+  adlBal?: string;
+  adlRecBal?: string;
+  /** @deprecated Returns "" per 2026-06-09 changelog */
+  adlRate?: string;
+  /** @deprecated Returns "" per 2026-06-09 changelog */
+  adlRecRate?: string;
+}
+
+export interface InsuranceFund {
+  instType?: string;
+  details: InsuranceFundDetail[];
+}
+
 export interface FundingRateHistory {
   /** Perpetual (`SWAP`) or X-Perp (`FUTURES`). */
   instType: string;

--- a/src/types/websockets/ws-api-response.ts
+++ b/src/types/websockets/ws-api-response.ts
@@ -5,6 +5,7 @@ export interface WSAPICancelOrderResultV5 {
   ordId: string;
   ts: numberInString;
   sCode: string;
+  subCode?: string;
   sMsg: string;
 }
 
@@ -13,6 +14,7 @@ export interface WSAPISpreadPlaceOrderResultV5 {
   ordId: string;
   tag: string;
   sCode: numberInString;
+  subCode?: string;
   sMsg: string;
 }
 
@@ -21,6 +23,7 @@ export interface WSAPISpreadAmendOrderResultV5 {
   ordId: string;
   reqId: string;
   sCode: string;
+  subCode?: string;
   sMsg: string;
 }
 
@@ -28,6 +31,7 @@ export interface WSAPISpreadCancelOrderResultV5 {
   clOrdId: string;
   ordId: string;
   sCode: string;
+  subCode?: string;
   sMsg: string;
 }
 

--- a/src/types/websockets/ws-events.ts
+++ b/src/types/websockets/ws-events.ts
@@ -16,9 +16,16 @@ export function isMessageEvent(msg: unknown): msg is MessageEventLike {
 }
 
 export interface WsEvent {
-  event: 'error' | 'login' | 'subscribe' | 'unsubscribe' | 'channel-conn-count';
+  event:
+    | 'error'
+    | 'login'
+    | 'subscribe'
+    | 'unsubscribe'
+    | 'channel-conn-count'
+    | 'notice';
   code?: string;
   msg?: string;
+  connId?: string;
   arg?: any;
   data?: any;
 }

--- a/src/types/websockets/ws-request.ts
+++ b/src/types/websockets/ws-request.ts
@@ -23,6 +23,7 @@ export type WsPrivateChannel =
   | 'orders-algo'
   | 'algo-advance'
   | 'liquidation-warning'
+  | 'adl-warning'
   | 'account-greeks'
   | 'grid-orders-spot'
   | 'grid-orders-contract'


### PR DESCRIPTION
# Release notes
Added move-positions REST endpoints for VIP6+ master accounts
Event contract series/events/markets are now public (no API key needed)
Asset bills history supports thirdPartyType filter (same as bills details)
Order place/amend responses include optional subCode for finer error detail
Typed security fund (insurance fund) endpoint; documented deprecated ADL fields
WS types for deprecated order book checksum, ADL warning channel, and upgrade notice events
Private account instruments include coin-denominated platform OI limit; fee groups include ELP maker rate

