### PR TITLE
chore(v3.2.0): upgrade GitHub Actions to setup-node v7 and checkout v6

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org/'

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -18,18 +18,18 @@ jobs:
       IS_PRERELEASE: ${{ github.event.release.prerelease }}
     steps:
       - name: Checkout (no repo token persisted)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org/
-          cache: 'npm'
+          package-manager-cache: false
 
       - name: Assert latest npm
         # run: npm i -g npm@latest # pin to v11 until npm v12 bug is fixed: https://github.com/npm/cli/issues/9722

--- a/.github/workflows/templates-readme.yml
+++ b/.github/workflows/templates-readme.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- Upgrade `actions/setup-node` v4 → v7
- Upgrade `actions/checkout` v4 → v6
- Disable npm cache in publish workflow (`package-manager-cache: false`) to reduce cache poisoning risk with OIDC trusted publishing

Ref: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc

## Test plan
- [ ] CI workflows run green on PR